### PR TITLE
Category filtering

### DIFF
--- a/peerinst/migrations/0009_auto_20150416_2103.py
+++ b/peerinst/migrations/0009_auto_20150416_2103.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import peerinst.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peerinst', '0008_auto_20150416_1142'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Category',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('title', models.CharField(help_text='Name of a category questions can be sorted into.', unique=True, max_length=100, verbose_name='Category Name', validators=[peerinst.models.no_hyphens])),
+            ],
+            options={
+                'verbose_name': 'category',
+                'verbose_name_plural': 'categories',
+            },
+        ),
+        migrations.AddField(
+            model_name='question',
+            name='category',
+            field=models.ForeignKey(blank=True, to='peerinst.Category', null=True),
+        ),
+    ]


### PR DESCRIPTION
Implements basic category assignment and filtering for questions.

To test:
1. Run the migrations
2. Add a category in the admin
3. Assign questions to categories
4. Go to an assignment and use the search bar on the questions element to sift through names. Category names can be filtered through along normal names as separate terms,
