### PR TITLE
Fix display of numeric answer style.

### DIFF
--- a/peerinst/models.py
+++ b/peerinst/models.py
@@ -117,9 +117,9 @@ class Question(models.Model):
         The iterable doesn't stop after the current number of answer choices.
         """
         if self.answer_style == Question.ALPHA:
-            return iter(string.uppercase)
+            return iter(string.ascii_uppercase)
         elif self.answer_style == Question.NUMERIC:
-            return itertools.count(1)
+            return itertools.imap(str, itertools.count(1))
         assert False, 'The field Question.answer_style has an invalid value.'
 
     def get_choice_label(self, index):
@@ -128,7 +128,7 @@ class Question(models.Model):
         This method does not check whether index is out of bounds.
         """
         if self.answer_style == Question.ALPHA:
-            return string.uppercase[index - 1]
+            return string.ascii_uppercase[index - 1]
         elif self.answer_style == Question.NUMERIC:
             return index
         assert False, 'The field Question.answer_style has an invalid value.'


### PR DESCRIPTION
The new code returns all answer labels as strings, regardless of whether they are numbers or letters, making it possible to call `str.join()` on them.  Unfortunately, Dalite NG doesn't have tests for views, so I didn't add any for this change.

The new version is already deployed on the [sandbox](http://54.191.134.85/admin/) and the [Harvard production instance](https://dalite.harvardx.harvard.edu/admin/).

To test, click on "Questions", add a new question with numeric answer style, save, open the question again and click "Preview" in the top right corner.

(I also changed `string.uppercase` to `string.ascii_uppercase` to make the labels independent from the locale of the server.)