### PR TITLE
Smarnach/lti error

### DIFF
--- a/peerinst/rationale_choice.py
+++ b/peerinst/rationale_choice.py
@@ -24,7 +24,7 @@ from django.utils.translation import ugettext_lazy as _
 from . import models
 
 
-class Error(Exception):
+class RationaleSelectionError(Exception):
     """Raised when an error occurs during rationale selection.
 
     The message attached to this exception will be shown to the user.
@@ -58,7 +58,9 @@ def simple(rand_seed, first_answer_choice, unused_entered_rationale, question):
         try:
             random_rationale = other_rationales[rng.randrange(other_rationales.count())]
         except ValueError:
-            raise Error(_("Can't proceed since the course staff did not provide example answers."))
+            raise RationaleSelectionError(
+                _("Can't proceed since the course staff did not provide example answers.")
+            )
         second_choice = random_rationale.first_answer_choice
     else:
         # Select a random correct answer.  We assume that a correct answer exists.

--- a/peerinst/views.py
+++ b/peerinst/views.py
@@ -218,12 +218,15 @@ class QuestionReviewView(QuestionFormView):
         kwargs = super(QuestionReviewView, self).get_form_kwargs()
         self.first_answer_choice = self.answer_dict['first_answer_choice']
         self.rationale = self.answer_dict['rationale']
-        self.rationale_choices = self.choose_rationales(
-            (self.user_token, self.assignment.pk, self.question.pk),
-            self.first_answer_choice,
-            self.rationale,
-            self.question,
-        )
+        try:
+            self.rationale_choices = self.choose_rationales(
+                (self.user_token, self.assignment.pk, self.question.pk),
+                self.first_answer_choice,
+                self.rationale,
+                self.question,
+            )
+        except rationale_choice.Error as e:
+            self.start_over(e.message)
         kwargs.update(rationale_choices=self.rationale_choices)
         return kwargs
 

--- a/peerinst/views.py
+++ b/peerinst/views.py
@@ -225,7 +225,7 @@ class QuestionReviewView(QuestionFormView):
                 self.rationale,
                 self.question,
             )
-        except rationale_choice.Error as e:
+        except rationale_choice.RationaleSelectionError as e:
             self.start_over(e.message)
         kwargs.update(rationale_choices=self.rationale_choices)
         return kwargs
@@ -292,7 +292,7 @@ class QuestionReviewView(QuestionFormView):
         answer.save()
 
     def send_grade(self):
-        custom_key = unicode(self.assignment.pk) + ':' + unicode(self.question.pk)
+        custom_key = unicode(self.assignment.pk) + u':' + unicode(self.question.pk)
         try:
             lti_data = LtiUserData.objects.get(user=self.request.user, custom_key=custom_key)
         except LtiUserData.DoesNotExist:

--- a/peerinst/views.py
+++ b/peerinst/views.py
@@ -292,11 +292,20 @@ class QuestionReviewView(QuestionFormView):
         answer.save()
 
     def send_grade(self):
+        custom_key = unicode(self.assignment.pk) + ':' + unicode(self.question.pk)
+        try:
+            lti_data = LtiUserData.objects.get(user=self.request.user, custom_key=custom_key)
+        except LtiUserData.DoesNotExist:
+            # We are running outside of an LTI context, so we don't need to send a grade.
+            return
+        if not lti_data.edx_lti_parameters.get('lis_outcome_service_url'):
+            # edX didn't provide a callback URL for grading, so this is an unscored problem.
+            return
         correct = self.question.answerchoice_set.all()[self.second_answer_choice - 1].correct
         Signals.Grade.updated.send(
             __name__,
             user=self.request.user,
-            custom_key=unicode(self.assignment.pk) + ':' + unicode(self.question.pk),
+            custom_key=custom_key,
             grade=float(correct),
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==1.8.1
+django==1.8.2
 django-grappelli==2.6.4
 mysql-python
 pillow


### PR DESCRIPTION
This PR fixes two bugs.

* Don't raise a 500 anymore when no example rationales are available, but show an error message instead.
* Don't send a grade for unscored problems.

The fix for the second bug is a bit of a hack, since we need to access some internals of the django-lti-tool-provider.  However, I think we can't do any better without some major refactoring of django-lti-tool-provider, and the solution is good enough.

The fix has the nice side effect that Dalite now fully works on Studio.

For testing, you can access the test course at https://edge.edx.org/courses/course-v1:HarvardX+TST-DALITE-NG-1+now/.  The second unit there uses the Dalite production instance, which is not updated yet, so it is still affected by the bugs.  The other units use the sandbox and should be fixed.  If you need access to the test course on Studio, please ask Xavier.