### PR TITLE
Show help message when third-party cookies are disabled.

### DIFF
--- a/peerinst/templates/peerinst/cookie_help.html
+++ b/peerinst/templates/peerinst/cookie_help.html
@@ -1,0 +1,19 @@
+{% extends 'peerinst/base.html' %}
+{% load i18n %}
+
+{% block title %}{{ Cookies }}{% endblock %}
+{% block body %}
+<p>
+  {% blocktrans %}
+  This component cannot be shown because your browser does not seem to accept third-party cookies.
+  You should configure your browser to allow all cookies for the site {{ host }} and reload this
+  page.
+  {% endblocktrans %}
+</p>
+<p>
+  {% blocktrans %}
+  In Internet Explorer, this can be done by going to Tools → Internet Options → Privacy → Sites,
+  entering {{ host }} in the address field and clicking "Allow".
+  {% endblocktrans %}
+</p>
+{% endblock %}


### PR DESCRIPTION
The tool currently doesn't work in Internet Explorer for some cookie privacy settings.  Internet Explorer uses some weird mechanism to disallow third-party cookies (called P3P policies), which would be hard for us to properly support.  As a much simpler solution, I included a help page that gets shown if the user doesn't have third-party cookies enabled for the Dalite site, explaining to the user how to make the tool work.

This is installed on the sandbox, and can be accessed via [an example on edge](https://edge.edx.org/courses/course-v1:HarvardX+TST-DALITE-NG-1+now/courseware/af9b85bee56b467cb0d7691c5e898035/56108c32a7bf4d87b77487c0714b8024/).  To be able to see this page correctly, you first have to navigate to https://54.149.53.180/ and convince your browser to accept the self-signed certificate from that page.  The LMS page should show correctly.  Then, remove all cookies for 54.149.53.180, block cookies for this host, and reload the LMS.  You should now get the help text.  Now enable cookies again, reload again and see the question again.

Unfortunately, there currently isn't a way of testing this from IE, since IE can't be convinced to load an iframe with a self-signed certificate.  I even tried adding the certificate as a trusted root certificate of the Windows installation, but to no avail.