### PR TITLE
Add new grading scheme

### DIFF
--- a/peerinst/admin.py
+++ b/peerinst/admin.py
@@ -78,12 +78,13 @@ class QuestionAdmin(admin.ModelAdmin):
         (_('Question image or video'), {'fields': ['image', 'image_alt_text', 'video_url']}),
         (None, {'fields': [
             'answer_style', 'fake_attributions', 'sequential_review',
-            'rationale_selection_algorithm'
+            'rationale_selection_algorithm', 'grading_scheme'
         ]}),
     ]
     radio_fields = {
         'answer_style': admin.HORIZONTAL,
         'rationale_selection_algorithm': admin.HORIZONTAL,
+        'grading_scheme': admin.HORIZONTAL,
     }
     readonly_fields = ['id']
     inlines = [AnswerChoiceInline, AnswerInline]

--- a/peerinst/migrations/0008_question_grading_scheme.py
+++ b/peerinst/migrations/0008_question_grading_scheme.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='question',
             name='grading_scheme',
-            field=models.IntegerField(default=0, help_text='Grading scheme to use. The "standard" scheme awards 1 point if the second answer provided by the student is correct, and 0 points otherwise. The "advanced" scheme awards 0.5 points for each correct answer.', verbose_name='Grading scheme', choices=[(0, 'standard'), (1, 'advanced')]),
+            field=models.IntegerField(default=0, help_text='Grading scheme to use. The "Standard" scheme awards 1 point if the student\'s final answer is correct, and 0 points otherwise. The "Advanced" scheme awards 0.5 points if the student\'s initial guess is correct, and 0.5 points if they subsequently stick with or change to the correct answer.', verbose_name='Grading scheme', choices=[(0, 'Standard'), (1, 'Advanced')]),
         ),
     ]

--- a/peerinst/migrations/0008_question_grading_scheme.py
+++ b/peerinst/migrations/0008_question_grading_scheme.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peerinst', '0007_answervote'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='question',
+            name='grading_scheme',
+            field=models.IntegerField(default=0, help_text='Grading scheme to use. The "standard" scheme awards 1 point if the second answer provided by the student is correct, and 0 points otherwise. The "advanced" scheme awards 0.5 points for each correct answer.', verbose_name='Grading scheme', choices=[(0, 'standard'), (1, 'advanced')]),
+        ),
+    ]

--- a/peerinst/models.py
+++ b/peerinst/models.py
@@ -115,16 +115,17 @@ class Question(models.Model):
         )
     )
     GRADING_SCHEME_CHOICES = (
-        (GradingScheme.STANDARD, 'standard'),
-        (GradingScheme.ADVANCED, 'advanced'),
+        (GradingScheme.STANDARD, _('Standard')),
+        (GradingScheme.ADVANCED, _('Advanced')),
     )
     grading_scheme = models.IntegerField(
         _('Grading scheme'), choices=GRADING_SCHEME_CHOICES, default=GradingScheme.STANDARD,
         help_text=_(
             'Grading scheme to use. '
-            'The "standard" scheme awards 1 point if the second answer '
-            'provided by the student is correct, and 0 points otherwise. '
-            'The "advanced" scheme awards 0.5 points for each correct answer.'
+            'The "Standard" scheme awards 1 point if the student\'s final answer is correct, '
+            'and 0 points otherwise. The "Advanced" scheme awards 0.5 points '
+            'if the student\'s initial guess is correct, and 0.5 points '
+            'if they subsequently stick with or change to the correct answer.'
         )
     )
 
@@ -259,7 +260,7 @@ class Answer(models.Model):
             grade = 0.
             if self.question.is_correct(self.first_answer_choice):
                 grade += 0.5
-            if self. question.is_correct(self.second_answer_choice):
+            if self.question.is_correct(self.second_answer_choice):
                 grade += 0.5
             return grade
 

--- a/peerinst/tests/test_models.py
+++ b/peerinst/tests/test_models.py
@@ -41,7 +41,7 @@ class AnswerModelTestCase(TestCase):
 
     def test_get_grade_standard(self):
         """
-        Check if `get_grade` produces correct values when using 'standard' grading scheme.
+        Check if `get_grade` produces correct values when using 'Standard' grading scheme.
 
         | First choice | Second choice | Grade |
         |--------------+---------------+-------|
@@ -54,7 +54,7 @@ class AnswerModelTestCase(TestCase):
 
     def test_get_grade_advanced(self):
         """
-        Check if `get_grade` produces correct values when using 'advanced' grading scheme.
+        Check if `get_grade` produces correct values when using 'Advanced' grading scheme.
 
         | First choice | Second choice | Grade |
         |--------------+---------------+-------|

--- a/peerinst/tests/test_models.py
+++ b/peerinst/tests/test_models.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+from django.test import TestCase
+
+from . import factories
+from ..models import GradingScheme
+
+
+class SelectedChoice(object):
+    CORRECT = 1
+    INCORRECT = 2
+
+
+class AnswerModelTestCase(TestCase):
+
+    def setUp(self):
+        super(AnswerModelTestCase, self).setUp()
+        # Create question with two choices (correct/incorrect):
+        self.question = factories.QuestionFactory(choices=2, choices__correct=[1])
+        # Create answers for question, considering all possible combinations of correctness values:
+        self.answers = []
+        selected_choices = (
+            (SelectedChoice.CORRECT, SelectedChoice.CORRECT),
+            (SelectedChoice.CORRECT, SelectedChoice.INCORRECT),
+            (SelectedChoice.INCORRECT, SelectedChoice.CORRECT),
+            (SelectedChoice.INCORRECT, SelectedChoice.INCORRECT),
+        )
+        for first_answer_choice, second_answer_choice in selected_choices:
+            answer = factories.AnswerFactory(
+                question=self.question,
+                first_answer_choice=first_answer_choice,
+                second_answer_choice=second_answer_choice
+            )
+            self.answers.append(answer)
+
+    def _assert_grades(self, expected_grades):
+        """ For each answer in `self.answers`, check if `get_grade` produces correct value. """
+        for index, answer in enumerate(self.answers):
+            grade = answer.get_grade()
+            self.assertEqual(grade, expected_grades[index])
+
+    def test_get_grade_standard(self):
+        """
+        Check if `get_grade` produces correct values when using 'standard' grading scheme.
+
+        | First choice | Second choice | Grade |
+        |--------------+---------------+-------|
+        | correct      | correct       | 1.0   |
+        | correct      | incorrect     | 0.0   |
+        | incorrect    | correct       | 1.0   |
+        | incorrect    | incorrect     | 0.0   |
+        """
+        self._assert_grades(expected_grades=[1.0, 0.0, 1.0, 0.0])
+
+    def test_get_grade_advanced(self):
+        """
+        Check if `get_grade` produces correct values when using 'advanced' grading scheme.
+
+        | First choice | Second choice | Grade |
+        |--------------+---------------+-------|
+        | correct      | correct       | 1.0   |
+        | correct      | incorrect     | 0.5   |
+        | incorrect    | correct       | 0.5   |
+        | incorrect    | incorrect     | 0.0   |
+        """
+        self.question.grading_scheme = GradingScheme.ADVANCED
+        self._assert_grades(expected_grades=[1.0, 0.5, 0.5, 0.0])

--- a/peerinst/tests/test_views.py
+++ b/peerinst/tests/test_views.py
@@ -5,14 +5,22 @@ import json
 import random
 
 from django.core.urlresolvers import reverse
-from django.test import Client, TestCase
+from django.test import TestCase
 from django_lti_tool_provider.models import LtiUserData
 from django_lti_tool_provider.views import LTIView
+
+import ddt
 import mock
 
 from ..util import SessionStageData
-from .. import views
 from . import factories
+
+
+class Grade(object):
+    CORRECT = 1.0
+    INCORRECT = 0.0
+    PARTIAL = 0.5
+
 
 class QuestionViewTestCase(TestCase):
 
@@ -37,8 +45,11 @@ class QuestionViewTestCase(TestCase):
             choices=5, choices__correct=[2, 4], choices__rationales=4,
         ))
         self.addCleanup(mock.patch.stopall)
-        patcher = mock.patch('django_lti_tool_provider.signals.Signals.Grade.updated.send')
-        self.mock_send_grade = patcher.start()
+        signal_patcher = mock.patch('django_lti_tool_provider.signals.Signals.Grade.updated.send')
+        self.mock_send_grade_signal = signal_patcher.start()
+        grade_patcher = mock.patch('peerinst.models.Answer.get_grade')
+        self.mock_get_grade = grade_patcher.start()
+        self.mock_get_grade.return_value = Grade.CORRECT
 
     def set_question(self, question):
         self.question = question
@@ -49,6 +60,11 @@ class QuestionViewTestCase(TestCase):
         )
         self.custom_key = unicode(self.assignment.pk) + ':' + unicode(question.pk)
         self.log_in_with_lti()
+
+    def disable_scoring(self):
+        lti_params = self.LTI_PARAMS.copy()
+        del lti_params['lis_outcome_service_url']
+        self.log_in_with_lti(lti_params=lti_params)
 
     def log_in_with_lti(self, user=None, password=None, lti_params=None):
         """Log a user in with fake LTI data."""
@@ -72,9 +88,13 @@ class QuestionViewTestCase(TestCase):
         response = self.client.post(self.question_url, form_data, follow=True)
         self.assertEqual(response.status_code, 200)
         return response
-        
+
 
 class QuestionViewTest(QuestionViewTestCase):
+
+    def assert_grade_signal(self, grade=Grade.INCORRECT):
+        send = mock.call('peerinst.views', user=self.user, custom_key=self.custom_key, grade=grade)
+        self.assertEqual(self.mock_send_grade_signal.call_args_list, [send] * 2)
 
     def run_standard_review_mode(self):
         """Test answering questions in default mode."""
@@ -126,20 +146,22 @@ class QuestionViewTest(QuestionViewTestCase):
 
     def test_standard_review_mode(self):
         """Test answering questions in default mode, with scoring enabled."""
+        self.mock_get_grade.return_value = Grade.INCORRECT
         self.run_standard_review_mode()
-        send = mock.call('peerinst.views', user=self.user, custom_key=self.custom_key, grade=0.0)
-        self.assertEqual(self.mock_send_grade.call_args_list, [send] * 2)
+        self.assert_grade_signal()
+        self.assertTrue(self.mock_get_grade.called)
 
-    def test_standard_review_mode_unscored(self):
+    def test_standard_review_mode_scoring_disabled(self):
         """Test answering questions in default mode, with scoring disabled."""
-        lti_params = self.LTI_PARAMS.copy()
-        del lti_params['lis_outcome_service_url']
-        self.log_in_with_lti(lti_params=lti_params)
+        self.disable_scoring()
         self.run_standard_review_mode()
-        self.assertFalse(self.mock_send_grade.called)
+        self.assertFalse(self.mock_send_grade_signal.called)
+        self.assertTrue(self.mock_get_grade.called)  # "emit_check_events" still uses "get_grade" to obtain grade data
 
     def test_sequential_review_mode(self):
         """Test answering questions in sequential review mode."""
+
+        self.mock_get_grade.return_value = Grade.INCORRECT
 
         self.set_question(factories.QuestionFactory(
             sequential_review=True,
@@ -203,32 +225,37 @@ class QuestionViewTest(QuestionViewTestCase):
         self.assertEqual(response.context['rationale'], rationale)
         self.assertEqual(response.context['chosen_rationale'].id, chosen_rationale)
 
+        self.assert_grade_signal()
+        self.assertTrue(self.mock_get_grade.called)
 
+
+@ddt.ddt
 class EventLogTest(QuestionViewTestCase):
 
-    def verify_event(self, logger):
+    def verify_event(self, logger, scoring_disabled=False):
         self.assertTrue(logger.info.called)
         event = json.loads(logger.info.call_args[0][0])
         self.assertEqual(event['context']['course_id'], self.COURSE_ID)
-        self.assertEqual(event['context']['module']['usage_key'], self.USAGE_ID)
+        self.assertEqual(event['context']['module']['usage_key'], None if scoring_disabled else self.USAGE_ID)
         self.assertEqual(event['context']['org_id'], self.ORG)
         self.assertEqual(event['event']['assignment_id'], self.assignment.pk)
         self.assertEqual(event['event']['question_id'], self.question.pk)
         self.assertEqual(event['username'], self.user.username)
+        if scoring_disabled:
+            self.assertIsNone(event['event'].get('grade'))
+            self.assertIsNone(event['event'].get('max_grade'))
         return event
 
-    @mock.patch('peerinst.views.LOGGER')
-    def test_events(self, logger):
-
+    def _test_events(self, logger, scoring_disabled=False, grade=Grade.CORRECT):
         # Show the question and verify the logged event.
         response = self.question_get()
-        event = self.verify_event(logger)
+        event = self.verify_event(logger, scoring_disabled=scoring_disabled)
         self.assertEqual(event['event_type'], 'problem_show')
         logger.reset_mock()
 
         # Provide a first answer and a rationale, and verify the logged event.
         response = self.question_post(first_answer_choice=2, rationale='my rationale text')
-        event = self.verify_event(logger)
+        event = self.verify_event(logger, scoring_disabled=scoring_disabled)
         self.assertEqual(event['event_type'], 'problem_check')
         self.assertEqual(event['event']['first_answer_choice'], 2)
         self.assertEqual(event['event']['success'], 'correct')
@@ -237,8 +264,22 @@ class EventLogTest(QuestionViewTestCase):
 
         # Select our own rationale and verify the logged event
         response = self.question_post(second_answer_choice=2, rationale_choice_0=None)
-        event = self.verify_event(logger)
+        event = self.verify_event(logger, scoring_disabled=scoring_disabled)
         self.assertEqual(logger.info.call_count, 2)
         self.assertEqual(event['event_type'], 'save_problem_success')
-        self.assertEqual(event['event']['success'], 'correct')
-        self.assertEqual(event['event']['grade'], 1.0)
+        self.assertEqual(event['event']['success'], 'correct' if grade == Grade.CORRECT else 'incorrect')
+
+        if not scoring_disabled:
+            self.assertEqual(event['event']['grade'], grade)
+            self.assertEqual(event['event']['max_grade'], Grade.CORRECT)
+
+    @ddt.data(Grade.CORRECT, Grade.INCORRECT, Grade.PARTIAL)
+    @mock.patch('peerinst.views.LOGGER')
+    def test_events_scoring_enabled(self, grade, logger):
+        self.mock_get_grade.return_value = grade
+        self._test_events(logger, grade=grade)
+
+    @mock.patch('peerinst.views.LOGGER')
+    def test_events_scoring_disabled(self, logger):
+        self.disable_scoring()
+        self._test_events(logger, scoring_disabled=True)

--- a/peerinst/views.py
+++ b/peerinst/views.py
@@ -71,12 +71,11 @@ class QuestionMixin(object):
         if not self.lti_data.edx_lti_parameters.get('lis_outcome_service_url'):
             # edX didn't provide a callback URL for grading, so this is an unscored problem.
             return
-        grade = self.answer.get_grade()
         Signals.Grade.updated.send(
             __name__,
             user=self.request.user,
             custom_key=self.custom_key,
-            grade=grade,
+            grade=self.answer.get_grade(),
         )
 
 

--- a/peerinst/views.py
+++ b/peerinst/views.py
@@ -4,13 +4,11 @@ from __future__ import unicode_literals
 import datetime
 import json
 import logging
-import math
 import random
 import re
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import redirect_to_login
-from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, render_to_response, redirect
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
@@ -66,19 +64,19 @@ class QuestionMixin(object):
         )
         return context
 
-    def send_grade(self, second_answer_choice):
+    def send_grade(self):
         if not self.lti_data:
             # We are running outside of an LTI context, so we don't need to send a grade.
             return
         if not self.lti_data.edx_lti_parameters.get('lis_outcome_service_url'):
             # edX didn't provide a callback URL for grading, so this is an unscored problem.
             return
-        correct = self.question.is_correct(second_answer_choice)
+        grade = self.answer.get_grade()
         Signals.Grade.updated.send(
             __name__,
             user=self.request.user,
             custom_key=self.custom_key,
-            grade=float(correct),
+            grade=grade,
         )
 
 
@@ -110,12 +108,17 @@ class QuestionFormView(QuestionMixin, FormView):
             usage_key = grade_handler_re.match(outcome_service_url)
             if usage_key:
                 usage_key = usage_key.group('usage_key')
+            # Grading is enabled, so include information about max grade in event data
+            data['max_grade'] = 1.0
+        else:
+            # Grading is not enabled, so remove information about grade from event data
+            if 'grade' in data:
+                del data['grade']
 
         # Add common fields to event data
         data.update(
             assignment_id=self.assignment.pk,
             assignment_title=self.assignment.title,
-            max_grade=1.0,
             problem=usage_key,
             question_id=self.question.pk,
             question_text=self.question.text,
@@ -355,15 +358,15 @@ class QuestionReviewView(QuestionReviewBaseView):
     def form_valid(self, form):
         self.second_answer_choice = int(form.cleaned_data['second_answer_choice'])
         self.chosen_rationale_id = int_or_none(form.cleaned_data['chosen_rationale_id'])
-        self.emit_check_events()
         self.save_answer()
+        self.emit_check_events()
         self.save_votes()
         self.stage_data.clear()
-        self.send_grade(self.second_answer_choice)
+        self.send_grade()
         return super(QuestionReviewView, self).form_valid(form)
 
     def emit_check_events(self):
-        correct = self.question.is_correct(self.second_answer_choice)
+        grade = self.answer.get_grade()
         event_data = dict(
             second_answer_choice=self.second_answer_choice,
             switch=self.first_answer_choice != self.second_answer_choice,
@@ -379,8 +382,8 @@ class QuestionReviewView(QuestionReviewBaseView):
                 if id is not None
             ],
             chosen_rationale_id=self.chosen_rationale_id,
-            success='correct' if correct else 'incorrect',
-            grade=float(correct),
+            success='correct' if grade == 1.0 else 'incorrect',
+            grade=grade,
         )
         self.emit_event('problem_check', **event_data)
         self.emit_event('save_problem_success', **event_data)
@@ -404,7 +407,7 @@ class QuestionReviewView(QuestionReviewBaseView):
         else:
             # We stuck with our own rationale.
             chosen_rationale = None
-        answer = models.Answer(
+        self.answer = models.Answer(
             question=self.question,
             assignment=self.assignment,
             first_answer_choice=self.first_answer_choice,
@@ -413,7 +416,7 @@ class QuestionReviewView(QuestionReviewBaseView):
             chosen_rationale=chosen_rationale,
             user_token=self.user_token,
         )
-        answer.save()
+        self.answer.save()
         if chosen_rationale is not None:
             self.record_fake_attribution_vote(chosen_rationale, models.AnswerVote.FINAL_CHOICE)
 
@@ -464,7 +467,7 @@ class QuestionSummaryView(QuestionMixin, TemplateView):
             rationale=self.answer.rationale,
             chosen_rationale=self.answer.chosen_rationale,
         )
-        self.send_grade(self.answer.second_answer_choice)
+        self.send_grade()
         return context
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,5 @@
 coverage
 factory_boy>=2.5.2,<2.6
 mock
+ddt
 pyyaml


### PR DESCRIPTION
Also, don't include information about "grade" and "max_grade" in logged event if scoring is disabled.

**Testing**

1. Set up Dalite NG as explained in the [README](https://github.com/open-craft/dalite-ng/blob/master/README.md).
2. With the development server running, go to http://localhost:8000/admin/ and log in using superuser credentials created as part of the previous step.
3. Create a new question:
   * Under "Management", click "Questions", then click "Add question" on the page that comes up.
   * Enter "Question title" and "Question text".
   * In the block that allows you to set "Answer style", check for an input field called "Grading scheme". This field was added as part of this PR and allows the course author to specify which grading scheme they would like to use. "standard" should be selected by default. Select "advanced" (the new grading scheme).
   * Add a couple of "Answer choices" by filling in the "Text" fields, and mark one of them as "Correct".
   * Click "Add another example answer", provide the "Rationale" for choosing the first answer and enter the number of the associated answer into the "Associated answer" field (`1` for the first answer). Repeat this step for the remaining "Answer choices" you created.
   * Click "Save".

To test the question you created, follow these steps (but note that the process of completing an assignment is the same, regardless of the grading scheme selected for a question; so the main purpose of doing this would be to verify that selecting the "advanced" grading scheme does not result in any errors):

1. Create a new assignment:
   * Under "Management", click "Assignments", then click "Add assignment" on the page that comes up.
   * Enter `assignment-1` for "Identifier" and `Assignment 1` for "Title".
   * Click "Choose all" to add the question you created in the previous step to the assignment.
   * Click "Save".
2. Navigate to the "main site" by clicking "View site" (in the top right corner). You should now be at this URL: http://localhost:8000/.
3. Click on the assignment you created in step 1, then click on the question you created in step 3 above.
4. Now you can complete the assignment by following the steps as they present themselves to you :)

To test in the LMS:

1. Ensure these settings are defined in dalite's `local_settings.py`: (You can change the values)
   
    ```python
LTI_CLIENT_KEY = 'alpha'
LTI_CLIENT_SECRET = 'beta'
PASSWORD_GENERATOR_NONCE = 'gamma'
```
2. Create a course and add `lti_consumer` to its advanced module list (if step 4 doesn't work, try `lti` in the advanced module list instead). 
3. In the advanced settings, go to "LTI Passports" and add `"dalite:alpha:beta"` to the list.
4. Add a new "Advanced > LTI" component to the course.
5. Edit the LTI component:
  
  a. Add two custom parameters: `assignment_id=assignment-1` and `question_id=1`.
  b. Set the LTI ID to `dalite`. Set the LTI URL to the URL of the dalite django app plus `/lti/`, e.g. if the app is running inside an edx vagrant devstack on port 8321, use `http://192.168.33.10:8321/lti/`
  c. Set "Open in New Page" false
  d. Set "Scored" to True
6. Add a second LTI component, but this time use `question_id=2` to get the second question.
7. Publish the Unit
8. Configure the Subsection that contains the unit, and set it to be graded as "Homework".
9. Enroll `honor@example.com`, `verified@example.com`, and `audit@example.com` in the course. Login as each of these users in turn. For one user, answer all the questions correctly and don't change your mind. For the next user, answer the questions wrong at first but then change your mind. For the third, get the answers wrong both times. Check the "Progress" page for each user and confirm the grades are as expected.