### PR TITLE
Added student login

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Setting up the development server
 
         $ export DALITE_DB_PASSWORD='your password here'
 
+   Or to use sqlite3, set in local_setting.py a line containing
+
+   DATABASES = { 'default' : { 'ENGINE' :  'django.db.backends.sqlite3', 'NAME': 'dalite_ng.sqlite3' } }
+
 3. Generate a secret key, e.g. using `tools/gen_secret_key.py`, an put it in
    `dalite/local_settings.py`.
 

--- a/dalite/settings.py
+++ b/dalite/settings.py
@@ -100,7 +100,7 @@ MEDIA_URL = '/media/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
-LOGIN_URL = 'admin:login'
+LOGIN_URL = 'peerinst_login'
 
 GRAPPELLI_ADMIN_TITLE = 'Dalite NG administration'
 

--- a/peerinst/templates/peerinst/login.html
+++ b/peerinst/templates/peerinst/login.html
@@ -1,0 +1,29 @@
+{% extends 'peerinst/base.html' %}
+{% load i18n %}
+
+{% block body %}
+
+    {% if form.errors %}
+        <p>Your username and password didn't match. Please try again.</p>
+    {% endif %}
+
+    <form method="post" action="{% url 'django.contrib.auth.views.login' %}">
+        {% csrf_token %}
+        <table>
+            <tr>
+                <td>{{ form.username.label_tag }}</td>
+                <td>{{ form.username }}</td>
+            </tr>
+            <tr>
+                <td>{{ form.password.label_tag }}</td>
+                <td>{{ form.password }}</td>
+            </tr>
+       </table>
+
+       <input type="submit" value="login" />
+       <input type="hidden" name="next" value="{{ next }}" />
+  </form>
+
+  <a href="{% url 'admin:login' %}">Teacher login</a>
+
+{% endblock %}

--- a/peerinst/urls.py
+++ b/peerinst/urls.py
@@ -8,6 +8,7 @@ from . import views
 
 urlpatterns = [
     url(r'^$', views.AssignmentListView.as_view(), name='assignment-list'),
+    url(r'^login/$', 'django.contrib.auth.views.login', { 'template_name': 'peerinst/login.html'}, name='peerinst_login'),
     url(r'^assignment/(?P<assignment_id>[^/]+)/', include([
         url(r'^$', views.QuestionListView.as_view(), name='question-list'),
         url(r'(?P<question_id>\d+)/', include([


### PR DESCRIPTION
So the students do not have access to the admin interface to answer the questions.

If you add to this PR a way to bulk create students accounts from a CSV file from the admin, you have a functional prototype.

By the way, when I tried to run it, I could see alternative justifications to the same answer I have chosen but not other answers and their justifications. There might a bug there.