### PR TITLE
CSRF Exempt views

### DIFF
--- a/dalite/settings.py
+++ b/dalite/settings.py
@@ -151,6 +151,10 @@ LTI_CLIENT_SECRET = os.environ.get('LTI_CLIENT_SECRET', None)
 PASSWORD_GENERATOR_NONCE = os.environ.get('PASSWORD_GENERATOR_NONCE', None)
 # LTI Integration end
 
+# Disables CSRF checks on peerinst views, allowing for multiple dalite LTI consumers to be displayed on the same page
+# and function properly
+CSRF_EXEMPT_PEERINST = False
+
 try:
     from .local_settings import *
 except ImportError:

--- a/dalite/tests.py
+++ b/dalite/tests.py
@@ -1,0 +1,88 @@
+import ddt
+import mock
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.db import IntegrityError
+from django.test import SimpleTestCase
+
+from dalite import ApplicationHookManager
+
+
+@ddt.ddt
+@mock.patch('dalite.User.objects')
+class ApplicationHookManagerTests(SimpleTestCase):
+    def setUp(self):
+        self.manager = ApplicationHookManager()
+
+    def _get_uname_and_password(self, user_id):
+        uname = self.manager._compress_user_name(user_id)
+        password = self.manager._generate_password(user_id, settings.PASSWORD_GENERATOR_NONCE)
+        return uname, password
+
+    @staticmethod
+    def user_does_not_exist_side_effect(username="irrelevant"):
+        raise User.DoesNotExist()
+
+    @staticmethod
+    def integrity_error_side_effect(username="irrelevant"):
+        raise IntegrityError()
+
+    @ddt.unpack
+    @ddt.data(
+        ('FN-2187', 'fn-2187@first_order.com', True),
+        ('Kylo Ren', None, False),
+    )
+    def test_authentication_hook_user_exists(self, user_id, email, auth_result, user_objects_manager):
+        user_objects_manager.get.return_value = User()
+        request = mock.Mock()
+        expected_uname, expected_password = self._get_uname_and_password(user_id)
+
+        with mock.patch('dalite.authenticate') as authenticate_mock, mock.patch('dalite.login') as login_mock:
+            authenticate_mock.return_value = auth_result
+            self.manager.authentication_hook(request, user_id, 'irrelevant', email)
+
+            authenticate_mock.assert_called_once_with(username=expected_uname, password=expected_password)
+            login_mock.assert_called_once_with(request, auth_result)
+
+    @ddt.unpack
+    @ddt.data(
+        ('Luke Skywalker', 'luke27@tatooine.com', True),
+        ('Ben Solo', None, False),
+    )
+    def test_authentication_hook_user_missing(self, user_id, email, auth_result, user_objects_manager):
+        user_objects_manager.get.side_effect = self.user_does_not_exist_side_effect
+        request = mock.Mock()
+        expected_uname, expected_password = self._get_uname_and_password(user_id)
+        expected_email = email = email if email else user_id+'@localhost'
+
+        with mock.patch('dalite.authenticate') as authenticate_mock, mock.patch('dalite.login') as login_mock:
+            authenticate_mock.return_value = auth_result
+            self.manager.authentication_hook(request, user_id, 'irrelevant', email)
+
+            user_objects_manager.create_user.assert_called_once_with(
+                username=expected_uname, email=expected_email, password=expected_password
+            )
+            authenticate_mock.assert_called_once_with(username=expected_uname, password=expected_password)
+            login_mock.assert_called_once_with(request, auth_result)
+
+    @ddt.unpack
+    @ddt.data(
+        ('Luke Skywalker', 'luke27@tatooine.com', True),
+        ('Ben Solo', None, False),
+    )
+    def test_authentication_hook_user_missing_integrity_error(self, user_id, email, auth_result, user_objects_manager):
+        user_objects_manager.get.side_effect = self.user_does_not_exist_side_effect
+        user_objects_manager.create.side_effect = self.integrity_error_side_effect
+        request = mock.Mock()
+        expected_uname, expected_password = self._get_uname_and_password(user_id)
+        expected_email = email = email if email else user_id+'@localhost'
+
+        with mock.patch('dalite.authenticate') as authenticate_mock, mock.patch('dalite.login') as login_mock:
+            authenticate_mock.return_value = auth_result
+            self.manager.authentication_hook(request, user_id, 'irrelevant', email)
+
+            user_objects_manager.create_user.assert_called_once_with(
+                username=expected_uname, email=expected_email, password=expected_password
+            )
+            authenticate_mock.assert_called_once_with(username=expected_uname, password=expected_password)
+            login_mock.assert_called_once_with(request, auth_result)

--- a/peerinst/views.py
+++ b/peerinst/views.py
@@ -9,6 +9,7 @@ import re
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import redirect_to_login
+from django.conf import settings
 from django.shortcuts import get_object_or_404, render_to_response, redirect
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
@@ -40,7 +41,10 @@ class CsrfExemptMixin(object):
     @classmethod
     def as_view(cls, **initkwargs):
         view = super(CsrfExemptMixin, cls).as_view(**initkwargs)
-        return csrf_exempt(view)
+        if settings.CSRF_EXEMPT_PEERINST:
+            return csrf_exempt(view)
+        else:
+            return view
 
 
 class AssignmentListView(LoginRequiredMixin, ListView):
@@ -491,7 +495,6 @@ def redirect_to_login_or_show_cookie_help(request):
     return redirect_to_login(request.get_full_path())
 
 
-@csrf_exempt
 def question(request, assignment_id, question_id):
     """Load common question data and dispatch to the right question stage.
 
@@ -544,3 +547,7 @@ def question(request, assignment_id, question_id):
         return redirect(request.path)
     stage_data.store()
     return result
+
+
+if settings.CSRF_EXEMPT_PEERINST:
+    question = csrf_exempt(question)


### PR DESCRIPTION
CSRF exempt peerinst views to allow multiple dalite instances in the same unit to work properly.

Testing instructions:
1. [Setup dalite](https://github.com/open-craft/dalite-ng/blob/master/README.md)
2. Create some questions and assignments (one question in one assignment theoretically should be enough, but at least three questions are recommended). This can be done via dalite admin interface (just django admin).
3. Add three lti_consumer blocks to the same unit, using instructions in [edX LTI documentation](http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/lti_component.html):
3.1. For dalite, tool URL should be http(s)://<dalite-address>/lti/
3.2. Dalite needs assignment and question IDs; they are configured as as assignment_id and question_id custom parameters in Custom Parameters field. Example: `["assignment_id=Assignment 1", "question_id=1"]` (not assignments are identified by their "name", while question IDs are integers)
4. Log in into LMS.
5. Make sure dalite cookies are **not** present, remove if necessary.
6. Navigate to the unit with three LTI consumer blocks.
7. Try submitting answers (and in general, follow the workflow to its end) with all three blocks. Note that even without this fix, at least one block would have worked anyway; and sometimes two worked ok, so test with all three.

Expected result: all three blocks accept answers, and it is possible to follow the workflow to till the end.
Failure condition: CSRF-caused 403 after submitting the response.