### PR TITLE
Multiple dalite in unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Setting up the development server
    run these commands as the MySQL superuser:
 
         mysql> CREATE DATABASE dalite_ng;
-        mysql> CREATE USER 'dalite' IDENTIFIED BY 'your password here';
+        mysql> CREATE USER 'dalite'@'localhost' IDENTIFIED BY 'your password here';
         mysql> GRANT ALL PRIVILEGES ON dalite_ng.* TO dalite;
 
    The password can be passed in the environment:

--- a/dalite/tests.py
+++ b/dalite/tests.py
@@ -1,0 +1,88 @@
+import ddt
+import mock
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.db import IntegrityError
+from django.test import SimpleTestCase
+
+from dalite import ApplicationHookManager
+
+
+@ddt.ddt
+@mock.patch('dalite.User.objects')
+class ApplicationHookManagerTests(SimpleTestCase):
+    def setUp(self):
+        self.manager = ApplicationHookManager()
+
+    def _get_uname_and_password(self, user_id):
+        uname = self.manager._compress_user_name(user_id)
+        password = self.manager._generate_password(user_id, settings.PASSWORD_GENERATOR_NONCE)
+        return uname, password
+
+    @staticmethod
+    def user_does_not_exist_side_effect(username="irrelevant"):
+        raise User.DoesNotExist()
+
+    @staticmethod
+    def integrity_error_side_effect(username="irrelevant"):
+        raise IntegrityError()
+
+    @ddt.unpack
+    @ddt.data(
+        ('FN-2187', 'fn-2187@first_order.com', True),
+        ('Kylo Ren', None, False),
+    )
+    def test_authentication_hook_user_exists(self, user_id, email, auth_result, user_objects_manager):
+        user_objects_manager.get.return_value = User()
+        request = mock.Mock()
+        expected_uname, expected_password = self._get_uname_and_password(user_id)
+
+        with mock.patch('dalite.authenticate') as authenticate_mock, mock.patch('dalite.login') as login_mock:
+            authenticate_mock.return_value = auth_result
+            self.manager.authentication_hook(request, user_id, 'irrelevant', email)
+
+            authenticate_mock.assert_called_once_with(username=expected_uname, password=expected_password)
+            login_mock.assert_called_once_with(request, auth_result)
+
+    @ddt.unpack
+    @ddt.data(
+        ('Luke Skywalker', 'luke27@tatooine.com', True),
+        ('Ben Solo', None, False),
+    )
+    def test_authentication_hook_user_missing(self, user_id, email, auth_result, user_objects_manager):
+        user_objects_manager.get.side_effect = self.user_does_not_exist_side_effect
+        request = mock.Mock()
+        expected_uname, expected_password = self._get_uname_and_password(user_id)
+        expected_email = email = email if email else user_id+'@localhost'
+
+        with mock.patch('dalite.authenticate') as authenticate_mock, mock.patch('dalite.login') as login_mock:
+            authenticate_mock.return_value = auth_result
+            self.manager.authentication_hook(request, user_id, 'irrelevant', email)
+
+            user_objects_manager.create_user.assert_called_once_with(
+                username=expected_uname, email=expected_email, password=expected_password
+            )
+            authenticate_mock.assert_called_once_with(username=expected_uname, password=expected_password)
+            login_mock.assert_called_once_with(request, auth_result)
+
+    @ddt.unpack
+    @ddt.data(
+        ('Luke Skywalker', 'luke27@tatooine.com', True),
+        ('Ben Solo', None, False),
+    )
+    def test_authentication_hook_user_missing_integrity_error(self, user_id, email, auth_result, user_objects_manager):
+        user_objects_manager.get.side_effect = self.user_does_not_exist_side_effect
+        user_objects_manager.create.side_effect = self.integrity_error_side_effect
+        request = mock.Mock()
+        expected_uname, expected_password = self._get_uname_and_password(user_id)
+        expected_email = email = email if email else user_id+'@localhost'
+
+        with mock.patch('dalite.authenticate') as authenticate_mock, mock.patch('dalite.login') as login_mock:
+            authenticate_mock.return_value = auth_result
+            self.manager.authentication_hook(request, user_id, 'irrelevant', email)
+
+            user_objects_manager.create_user.assert_called_once_with(
+                username=expected_uname, email=expected_email, password=expected_password
+            )
+            authenticate_mock.assert_called_once_with(username=expected_uname, password=expected_password)
+            login_mock.assert_called_once_with(request, auth_result)

--- a/peerinst/templates/peerinst/base.html
+++ b/peerinst/templates/peerinst/base.html
@@ -17,6 +17,26 @@
   <body>
     {% block body %}{% endblock %}
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+    <script>
+        // Fix potential CSRF token conflicts when loading multiple iframes in parallel,
+        // if the user did not have a CSRF cookie set already.
+        // The CSRF token in the HTML may be out of date, but the cookie value should be
+        // accurate by the time we submit the form.
+        $(function() {
+            var getCookie = function(name) {
+                var match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+                if (match) { return match[2]; }
+            };
+            $(document).on('submit','form', function(){
+                var csrf_token = getCookie('csrftoken');
+                if (csrf_token) {
+                    $('input[name=csrfmiddlewaretoken]').each(function() {
+                        $(this).val(csrf_token);
+                    });
+                }
+            });
+        });
+    </script>
     {% block scripts %}{% endblock %}
   </body>
 </html>


### PR DESCRIPTION
CSRF exempt peerinst views to allow multiple dalite instances in the same unit to work properly.

**Testing instructions:**
1. Configure dalite
1.1. [Setup dalite](https://github.com/open-craft/dalite-ng/blob/master/README.md)
1.2. Create some questions and assignments (one question in one assignment theoretically should be enough, but at least three questions are recommended). This can be done via dalite admin interface (just django admin).
1.3. More detailed instructions are aailable at https://github.com/open-craft/dalite-ng/pull/29
2. Add three lti_consumer blocks to the same unit, using instructions in [edX LTI documentation](http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/lti_component.html):
2.1. For dalite, tool URL should be http(s)://<dalite-address>/lti/
2.2. Dalite needs assignment and question IDs; they are configured as as assignment_id and question_id custom parameters in Custom Parameters field. Example: `["assignment_id=Assignment 1", "question_id=1"]` (not assignments are identified by their "name", while question IDs are integers)
3. Check all three blocks work as they should
3.1. Log in into LMS.
3.2. Make sure dalite cookies are **not** present, remove if necessary.
3.3. Navigate to the unit with three LTI consumer blocks.
3.4. Try submitting answers (and in general, follow the workflow to its end) with all three blocks. Note that even without this fix, at least one block would have worked anyway; and sometimes two worked ok, so test with all three.

Expected result: all three blocks accept answers, and it is possible to follow the workflow to till the end.
Failure condition: CSRF-caused 403 after submitting the response.