### PR TITLE
JS-based fix for CSRF race condition

### DIFF
--- a/peerinst/templates/peerinst/base.html
+++ b/peerinst/templates/peerinst/base.html
@@ -17,6 +17,26 @@
   <body>
     {% block body %}{% endblock %}
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+    <script>
+        // Fix potential CSRF token conflicts when loading multiple iframes in parallel,
+        // if the user did not have a CSRF cookie set already.
+        // The CSRF token in the HTML may be out of date, but the cookie value should be
+        // accurate by the time we submit the form.
+        $(function() {
+            var getCookie = function(name) {
+                var match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+                if (match) { return match[2]; }
+            };
+            $(document).on('submit','form', function(){
+                var csrf_token = getCookie('csrftoken');
+                if (csrf_token) {
+                    $('input[name=csrfmiddlewaretoken]').each(function() {
+                        $(this).val(csrf_token);
+                    });
+                }
+            });
+        });
+    </script>
     {% block scripts %}{% endblock %}
   </body>
 </html>


### PR DESCRIPTION
This PR achieves multiple dalite on the same page by overwriting csrf hidden control with value from a cookie