### PR TITLE
Add explicit ordering directive for answer choices to ensure consistency.

### DIFF
--- a/peerinst/migrations/0009_auto_20160210_2236.py
+++ b/peerinst/migrations/0009_auto_20160210_2236.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peerinst', '0008_question_grading_scheme'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='answerchoice',
+            options={'ordering': ['id'], 'verbose_name': 'answer choice', 'verbose_name_plural': 'answer choices'},
+        ),
+    ]

--- a/peerinst/models.py
+++ b/peerinst/models.py
@@ -198,6 +198,7 @@ class AnswerChoice(models.Model):
         return self.text
 
     class Meta:
+        ordering = ['id']
         verbose_name = _('answer choice')
         verbose_name_plural = _('answer choices')
 


### PR DESCRIPTION
The code makes the implicit assumption that answer choices are ordered by id consistently.  MySQL seems to return query results in that order even without the explicit request to do so, but we definitely shouldn't rely on this behaviour.