### PR TITLE
Return numeric labels as strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,12 @@ Running the tests
 The tests can be run with
 
 ```
+dalite$ export PASSWORD_GENERATOR_NONCE=some_random_string
 dalite$ make test
 ```
+
+(If you have set `PASSWORD_GENERATOR_NONCE` in your settings you don't need the
+export statement above.)
 
 After the tests have finished, you can view the coverage report using:
 

--- a/peerinst/models.py
+++ b/peerinst/models.py
@@ -171,7 +171,7 @@ class Question(models.Model):
         elif self.answer_style == Question.ALPHA:
             return string.ascii_uppercase[index - 1]
         elif self.answer_style == Question.NUMERIC:
-            return index
+            return str(index)
         assert False, 'The field Question.answer_style has an invalid value.'
 
     def get_choices(self):

--- a/peerinst/tests/test_views.py
+++ b/peerinst/tests/test_views.py
@@ -12,6 +12,7 @@ from django_lti_tool_provider.views import LTIView
 import ddt
 import mock
 
+from ..models import Question
 from ..util import SessionStageData
 from . import factories
 
@@ -160,6 +161,14 @@ class QuestionViewTest(QuestionViewTestCase):
         self.run_standard_review_mode()
         self.assert_grade_signal()
         self.assertTrue(self.mock_get_grade.called)
+
+    def test_numeric_answer_labels(self):
+        """Test answering questions in default mode, using numerical labels."""
+        self.set_question(factories.QuestionFactory(
+            answer_style=Question.NUMERIC,
+            choices=5, choices__correct=[2, 4], choices__rationales=4,
+        ))
+        self.run_standard_review_mode()
 
     def test_standard_review_mode_scoring_disabled(self):
         """Test answering questions in default mode, with scoring disabled."""

--- a/peerinst/views.py
+++ b/peerinst/views.py
@@ -461,8 +461,8 @@ class QuestionSummaryView(QuestionMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super(QuestionSummaryView, self).get_context_data(**kwargs)
         context.update(
-            first_choice_label=self.question.get_choice_label(self.answer.first_answer_choice),
-            second_choice_label=self.question.get_choice_label(self.answer.second_answer_choice),
+            first_choice_label=self.answer.first_answer_choice_label(),
+            second_choice_label=self.answer.second_answer_choice_label(),
             rationale=self.answer.rationale,
             chosen_rationale=self.answer.chosen_rationale,
         )


### PR DESCRIPTION
Labels should be strings.  The old version was inconsistent: `get_choice_label_iter()` always returned strings, while `get_choice_label()` returned strings for alphabetic labels and ints for numeric labels.  This resulted in a display bug, because the values returned by the two functions were compared for equality to decide which answer to highlight as first and second choice.