### PR TITLE
Shows top rationales for a given question

### DIFF
--- a/peerinst/admin.py
+++ b/peerinst/admin.py
@@ -109,7 +109,8 @@ publish_answers.short_description = _('Show selected answers to students')
 @admin.register(Answer)
 class AnswerAdmin(admin.ModelAdmin):
     list_display = ['question', 'user_token', 'first_answer_choice_label', 'second_answer_choice_label',
-                    'rationale', 'show_to_others', 'expert', 'upvotes', 'downvotes']
+                    'rationale', 'show_to_others', 'expert', 'chosen_rationale', 'upvotes', 'downvotes']
     list_display_links = None
     list_editable = ['show_to_others', 'expert']
+    list_filter=['chosen_rationale']
     actions = [publish_answers]

--- a/peerinst/fixtures/peerinst_test_data.yaml
+++ b/peerinst/fixtures/peerinst_test_data.yaml
@@ -32,32 +32,35 @@
     title: Assignment title 1
   model: peerinst.assignment
   pk: Assignment1
-- fields: {assignment: Assignment1, chosen_rationale: null, first_answer_choice: 1,
+- fields: {assignment: Assignment1, chosen_rationale: 861, first_answer_choice: 1,
     question: 29, rationale: Rationale text 1 for choice 1, second_answer_choice: 3,
+    upvotes: 10, downvotes: 1,
     show_to_others: true, user_token: rhtof}
   model: peerinst.answer
   pk: 855
 - fields: {assignment: Assignment1, chosen_rationale: null, first_answer_choice: 1,
     question: 29, rationale: Rationale text 2 for choice 1, second_answer_choice: 2,
+    upvotes: 9, downvotes: 2,
     show_to_others: true, user_token: esbxa}
   model: peerinst.answer
   pk: 856
-- fields: {assignment: Assignment1, chosen_rationale: null, first_answer_choice: 1,
+- fields: {assignment: Assignment1, chosen_rationale: 861, first_answer_choice: 1,
     question: 29, rationale: Rationale text 3 for choice 1, second_answer_choice: 3,
+    upvotes: 8, downvotes: 3,
     show_to_others: true, user_token: upjwt}
   model: peerinst.answer
   pk: 857
-- fields: {assignment: Assignment1, chosen_rationale: null, first_answer_choice: 2,
+- fields: {assignment: Assignment1, chosen_rationale: 864, first_answer_choice: 2,
     question: 29, rationale: Rationale text 1 for choice 2, second_answer_choice: 4,
     show_to_others: true, user_token: rhtof}
   model: peerinst.answer
   pk: 858
-- fields: {assignment: Assignment1, chosen_rationale: null, first_answer_choice: 2,
+- fields: {assignment: Assignment1, chosen_rationale: 865, first_answer_choice: 2,
     question: 29, rationale: Rationale text 2 for choice 2, second_answer_choice: 4,
     show_to_others: true, user_token: nrqek}
   model: peerinst.answer
   pk: 859
-- fields: {assignment: Assignment1, chosen_rationale: null, first_answer_choice: 2,
+- fields: {assignment: Assignment1, chosen_rationale: 861, first_answer_choice: 2,
     question: 29, rationale: Rationale text 3 for choice 2, second_answer_choice: 3,
     show_to_others: true, user_token: bmnwf}
   model: peerinst.answer
@@ -102,7 +105,7 @@
     show_to_others: true, user_token: ''}
   model: peerinst.answer
   pk: 868
-- fields: {assignment: Assignment1, chosen_rationale: null, first_answer_choice: 5,
+- fields: {assignment: Assignment1, chosen_rationale: 856, first_answer_choice: 5,
     question: 29, rationale: Rationale text 3 for choice 5, second_answer_choice: 1,
     show_to_others: true, user_token: eeawg}
   model: peerinst.answer

--- a/peerinst/static/peerinst/css/admin.css
+++ b/peerinst/static/peerinst/css/admin.css
@@ -21,3 +21,7 @@
 .attribution-stats-container {
     margin-top: 2ex;
 }
+
+.results-rationale-data {
+    margin-bottom: 2ex;
+}

--- a/peerinst/templates/admin/peerinst/question_rationales.html
+++ b/peerinst/templates/admin/peerinst/question_rationales.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n staticfiles grp_tags %}
 
-{% block title %}{% trans 'Assignment results' %}{% endblock %}
+{% block title %}{% trans 'Question rationales' %}{% endblock %}
 
 {% block extrastyle %}
 <link href="{% static 'peerinst/css/admin.css' %}" rel="stylesheet" type="text/css" />
@@ -10,12 +10,13 @@
 {% block breadcrumbs %}
 <ul>
   <li><a href="{% url 'admin-index' %}">{% trans 'Home' %}</a></li>
-  <li>{{ assignment.identifier }} {% trans 'results' %}</li>
+  <li><a href="{% url 'assignment-results' assignment_id=assignment.identifier %}">{% trans 'results' %}</a></li>
+  <li>{{ question.title }} {% trans 'rationales' %}</li>
 </ul>
 {% endblock %}
 
 {% block content_title %}
-<h1>{% trans 'Results for the assignment' %} {{ assignment.identifier }}</h1>
+<h1>{% trans 'Rationales for answers to ' %} {{ question.title }}</h1>
 {% endblock %}
 
 {% block content %}
@@ -23,36 +24,38 @@
   <h2>Summary</h2>
   <table class="results-summary">
     <tbody>
-      {% for label, item in assignment_data %}
+      {% for label, item in summary_data %}
       <tr><th>{{ label }}</th><td>{{ item }}</td></tr>
       {% endfor %}
     </tbody>
   </table>
 </div>
 <div class="g-d-c-fluid">
-  <h2>Results for individual questions</h2>
-  <table class="results-question-data">
+  {% for data in rationale_data %}
+  <h2>{{ data.heading }}</h2>
+  <table class="results-rationale-data">
     <thead>
       <tr>
-        {% for label in question_data.labels %}
+        {% for label in data.labels %}
         <th>{{ label }}</th>
         {% endfor %}
       </tr>
     </thead>
     <tbody>
-      {% for question in question_data.rows %}
+      {% for rationale in data.rows %}
       <tr class="grp-row-{% cycle 'odd' 'even' %}">
-        {% for item in question.data %}
+        {% for item in rationale.data %}
         <td>{{ item }}</td>
         {% endfor %}
         <td>
-          <a href="{{ question.link_this }}">[{% trans 'this assignment' %}]</a>
-          <a href="{{ question.link_all }}">[{% trans 'all' %}]</a>
-          <a href="{{ question.link_rationales }}">[{% trans 'rationales' %}]</a>
+        {% if rationale.link_answers %}
+        <a href="{{ rationale.link_answers }}">[{% trans 'answers' %}]</a>
+        {% endif %}
         </td>
       </tr>
       {% endfor %}
     </tbody>
   </table>
+  {% endfor %}
 </div>
 {% endblock %}

--- a/peerinst/tests/test_admin_views.py
+++ b/peerinst/tests/test_admin_views.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, unicode_literals
+import ddt
 
 from django.test import TestCase
+from django.core.urlresolvers import reverse
+from . import factories
 from .. import admin_views
 from .. import models
 
 
+@ddt.ddt
 class AggregatesTestCase(TestCase):
     fixtures = ['peerinst_test_data']
 
@@ -60,3 +64,207 @@ class AggregatesTestCase(TestCase):
             'total_students': 13,
         }
         self.assertDictEqual(dict(sums), expected_sums)
+
+    @ddt.unpack
+    @ddt.data(
+        ('Assignment1', 29,
+         {
+             'upvoted': 3,
+             'chosen': 5,
+             'wrong_to_right': 2,
+             'right_to_wrong': 3,
+         }, {
+             'upvoted': [
+                 {'count': 10, 'rationale': 855},
+                 {'count': 9, 'rationale': 856},
+                 {'count': 8, 'rationale': 857},
+             ],
+             'chosen': [
+                 {'count': 8, 'rationale': None},
+                 {'count': 3, 'rationale': 861},
+                 {'count': 1, 'rationale': 864},
+                 {'count': 1, 'rationale': 865},
+                 {'count': 1, 'rationale': 856},
+             ],
+             'right_to_wrong': [
+                 {'count': 3, 'rationale': 861},
+                 {'count': 1, 'rationale': 864},
+                 {'count': 1, 'rationale': 865},
+             ],
+             'wrong_to_right': [
+                 {'count': 1, 'rationale': 856},
+                 {'count': 1, 'rationale': None},
+             ],
+         }),
+        # Empty case - no chosen_rationales set, no upvotes given
+        ('Assignment1', 30,
+         {
+             'upvoted': 0,
+             'chosen': 1,
+             'wrong_to_right': 1,
+             'right_to_wrong': 1,
+         }, {
+             'upvoted': [],
+             'chosen': [
+                 {'count': 6, 'rationale': None},
+             ],
+             'wrong_to_right': [
+                 {'count': 3, 'rationale': None},
+             ],
+             'right_to_wrong': [
+                 {'count': 3, 'rationale': None},
+             ],
+         })
+    )
+    def test_get_question_rationale_aggregates(self, assign_id, question_id, expected_sums, expected_rationales):
+        assignment = models.Assignment.objects.get(identifier=assign_id)
+        question = models.Question.objects.get(id=question_id)
+        sums, rationales = admin_views.get_question_rationale_aggregates(assignment, question)
+        self.assertDictEqual(dict(sums), expected_sums)
+
+        # Fetch the actual objects from the ids in the test data
+        for data in expected_rationales.values():
+            for item in data:
+                rationale_id = item.get('rationale')
+                if rationale_id:
+                    item['rationale'] = models.Answer.objects.get(id=rationale_id)
+        self.assertDictEqual(rationales, expected_rationales)
+
+
+@ddt.ddt
+class QuestionRationaleViewTestCase(TestCase):
+    fixtures = ['peerinst_test_data']
+
+    def setUp(self):
+        super(QuestionRationaleViewTestCase, self).setUp()
+        self.admin_user = factories.UserFactory()
+        self.admin_user.is_staff = True
+        self.admin_user.save()
+
+    @ddt.unpack
+    @ddt.data(
+        ('Assignment1', 29, [
+            ('Total rationales upvoted', 3),
+            ('Total rationales chosen', 5),
+            ('Total rationales chosen for right to wrong answer switches', 3),
+            ('Total rationales chosen for wrong to right answer switches', 2),
+        ], [
+            {
+                'heading': 'Upvoted rationales',
+                'labels': ['Count', 'Rationale', 'Upvotes', 'Downvotes', 'Answers with this chosen rationale'],
+                'rows': [
+                    {
+                        'data': [10, 'Rationale text 1 for choice 1', 10, 1],
+                        'link_answers': '/admin/peerinst/answer/?chosen_rationale__id__exact=855',
+                    },
+                    {
+                        'data': [9, 'Rationale text 2 for choice 1', 9, 2],
+                        'link_answers': '/admin/peerinst/answer/?chosen_rationale__id__exact=856',
+                    },
+                    {
+                        'data': [8, 'Rationale text 3 for choice 1', 8, 3],
+                        'link_answers': u'/admin/peerinst/answer/?chosen_rationale__id__exact=857',
+                    }
+                ]
+            }, {
+                'heading': 'Top rationales chosen',
+                'labels': ['Count', 'Rationale', 'Upvotes', 'Downvotes', 'Answers with this chosen rationale'],
+                'rows': [
+                    {
+                        'data': [8, '(Student stuck to own rationale)', u'', u''],
+                        'link_answers': u'/admin/peerinst/answer/?chosen_rationale__isnull=True',
+                    },
+                    {
+                        'data': [3, 'Rationale text 1 for choice 3', 0, 0],
+                        'link_answers': '/admin/peerinst/answer/?chosen_rationale__id__exact=861',
+                    },
+                    {
+                        'data': [1, 'Rationale text 1 for choice 4', 0, 0],
+                        'link_answers': '/admin/peerinst/answer/?chosen_rationale__id__exact=864',
+                    },
+                    {
+                        'data': [1, 'Rationale text 2 for choice 4', 0, 0],
+                        'link_answers': '/admin/peerinst/answer/?chosen_rationale__id__exact=865',
+                    },
+                    {
+                        'data': [1, 'Rationale text 2 for choice 1', 9, 2],
+                        'link_answers': '/admin/peerinst/answer/?chosen_rationale__id__exact=856',
+                    },
+                ]
+            }, {
+                'heading': 'Top rationales chosen for right to wrong answer switches',
+                'labels': ['Count', 'Rationale', 'Upvotes', 'Downvotes', 'Answers with this chosen rationale'],
+                'rows': [
+                    {
+                        'data': [3, 'Rationale text 1 for choice 3', 0, 0],
+                        'link_answers': '/admin/peerinst/answer/?chosen_rationale__id__exact=861',
+                    },
+                    {
+                        'data': [1, 'Rationale text 1 for choice 4', 0, 0],
+                        'link_answers': '/admin/peerinst/answer/?chosen_rationale__id__exact=864',
+                    },
+                    {
+                        'data': [1, 'Rationale text 2 for choice 4', 0, 0],
+                        'link_answers': '/admin/peerinst/answer/?chosen_rationale__id__exact=865',
+                    },
+                ]
+            }, {
+                'heading': 'Top rationales chosen for wrong to right answer switches',
+                'labels': ['Count', 'Rationale', 'Upvotes', 'Downvotes', 'Answers with this chosen rationale'],
+                'rows': [
+                    {
+                        'data': [1, 'Rationale text 2 for choice 1', 9, 2],
+                        'link_answers': '/admin/peerinst/answer/?chosen_rationale__id__exact=856',
+                    },
+                    {
+                        'data': [1, '(Student stuck to own rationale)', u'', u''],
+                        'link_answers': u'/admin/peerinst/answer/?chosen_rationale__isnull=True',
+                    },
+                ]
+            }
+        ]),
+        ('Assignment1', 30, [
+            ('Total rationales upvoted', 0),
+            ('Total rationales chosen', 1),
+            ('Total rationales chosen for right to wrong answer switches', 1),
+            ('Total rationales chosen for wrong to right answer switches', 1),
+        ], [
+            {
+                'heading': 'Upvoted rationales',
+                'labels': ['Count', 'Rationale', 'Upvotes', 'Downvotes', 'Answers with this chosen rationale'],
+                'rows': []
+            },
+            {
+                'heading': 'Top rationales chosen',
+                'labels': ['Count', 'Rationale', 'Upvotes', 'Downvotes', 'Answers with this chosen rationale'],
+                'rows': [{
+                    'data': [6, '(Student stuck to own rationale)', u'', u''],
+                    'link_answers': u'/admin/peerinst/answer/?chosen_rationale__isnull=True',
+                }]
+            },
+            {
+                'heading': 'Top rationales chosen for right to wrong answer switches',
+                'labels': ['Count', 'Rationale', 'Upvotes', 'Downvotes', 'Answers with this chosen rationale'],
+                'rows': [{
+                    'data': [3, '(Student stuck to own rationale)', u'', u''],
+                    'link_answers': u'/admin/peerinst/answer/?chosen_rationale__isnull=True',
+                }]
+            },
+            {
+                'heading': 'Top rationales chosen for wrong to right answer switches',
+                'labels': ['Count', 'Rationale', 'Upvotes', 'Downvotes', 'Answers with this chosen rationale'],
+                'rows': [{
+                    'data': [3, '(Student stuck to own rationale)', u'', u''],
+                    'link_answers': u'/admin/peerinst/answer/?chosen_rationale__isnull=True',
+                }]
+            },
+        ])
+    )
+    def test_view(self, assign_id, question_id, expected_summary_data, expected_rationale_data):
+        self.client.login(username=self.admin_user.username, password='test')
+
+        url = reverse('question-rationales', kwargs=dict(assignment_id=assign_id, question_id=question_id))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertListEqual(response.context['summary_data'], expected_summary_data)
+        self.assertListEqual(response.context['rationale_data'], expected_rationale_data)

--- a/peerinst/urls.py
+++ b/peerinst/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     url(r'^admin/peerinst/', include([
         url(r'^assignment_results/(?P<assignment_id>[^/]+)/', include([
             url(r'^$', admin_views.AssignmentResultsView.as_view(), name='assignment-results'),
+            url(r'^rationales/(?P<question_id>\d+)$', admin_views.QuestionRationaleView.as_view(), name='question-rationales'),
         ])),
         url(r'^question_preview/(?P<question_id>[^/]+)$',
             admin_views.QuestionPreviewView.as_view(), name='question-preview'),


### PR DESCRIPTION
* Adds peerinst.admin_views.get_question_rationale_aggregates() and unit tests
* Adds peerinst.admin_views.QuestionRationaleView to display rationale, using
  question_rationales.html template
* Adds link to the individual questions table in the assignment results admin page

**JIRA tickets**: [OC-1536](https://tasks.opencraft.com/browse/OC-1536)

**Screenshots**:
![screen shot 2016-04-26 at 6 06 22 pm](https://cloud.githubusercontent.com/assets/7556571/14811892/aa9b872e-0bd9-11e6-8e46-a2f79a8f2148.png)
![screen shot 2016-04-26 at 6 06 13 pm](https://cloud.githubusercontent.com/assets/7556571/14811897/b0d91566-0bd9-11e6-94db-7417e2819466.png)

**Testing instructions**:

1. Follow instructions in [README](https://github.com/open-craft/dalite-ng/blob/jill/fix-readme/README.md) to set up development environment and create a superuser.
1. [Run tests and verify coverage](https://github.com/open-craft/dalite-ng/blob/jill/fix-readme/README.md#running-the-tests)
1. Optionally load the test fixture data, or create your own assignments, questions, and responses.
```
./manage.py loaddata peerinst/fixtures/peerinst_test_data.yaml
``` 
1. Run the development server
```
./manage.py runserver
``` 
1. Navigate to http://127.0.0.1:8000/admin/ and click on an assignment under 'Student progress by assignment'.  From there, find the question table, and click on 'rationales' to see the new report.

**Reviewers**
- [ ] OpenCraft reviewer TBD