### PR TITLE
Limits the number of rationales shown on the Top Rationales report

### DIFF
--- a/peerinst/templates/admin/peerinst/question_rationales.html
+++ b/peerinst/templates/admin/peerinst/question_rationales.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n staticfiles grp_tags %}
 
-{% block title %}{% trans 'Question rationales' %}{% endblock %}
+{% block title %}{{ question.title }}: {% blocktrans %}Top {{ perpage }} Rationales{% endblocktrans %}{% endblock %}
 
 {% block extrastyle %}
 <link href="{% static 'peerinst/css/admin.css' %}" rel="stylesheet" type="text/css" />
@@ -10,13 +10,14 @@
 {% block breadcrumbs %}
 <ul>
   <li><a href="{% url 'admin-index' %}">{% trans 'Home' %}</a></li>
-  <li><a href="{% url 'assignment-results' assignment_id=assignment.identifier %}">{% trans 'results' %}</a></li>
-  <li>{{ question.title }} {% trans 'rationales' %}</li>
+  <li><a href="{% url 'assignment-results' assignment_id=assignment.identifier %}">{{ assignment.identifier }}</a></li>
+  <li><a href="{% url 'question-preview' question_id=question.id %}">{{ question }}</a></li>
+  <li>{% blocktrans %}Top {{ perpage }} rationales {% endblocktrans %}</li>
 </ul>
 {% endblock %}
 
 {% block content_title %}
-<h1>{% trans 'Rationales for answers to ' %} {{ question.title }}</h1>
+<h1>{% blocktrans %}Top {{ perpage }} rationales for answers to {{ question }}{% endblocktrans %}</h1>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Adds a "perpage" parameter, which limits the number of rationales shown.  Defaults to `models.AnswerAdmin.list_per_page=100`.

**JIRA tickets**: [OC-1536](https://tasks.opencraft.com/browse/OC-1536)

**Screenshots**:

![screen shot 2016-05-01 at 4 17 45 pm](https://cloud.githubusercontent.com/assets/7556571/14940519/606358ca-0fb8-11e6-84d1-b055f5f737ef.png)

**Testing instructions**:

1. Follow instructions in [README](https://github.com/open-craft/dalite-ng/blob/master/README.md) to set up development environment and create a superuser.
1. [Run tests and verify coverage](https://github.com/open-craft/dalite-ng/blob/master/README.md#running-the-tests)
1. Optionally load the test fixture data, or create your own assignments, questions, and responses.
```
./manage.py loaddata peerinst/fixtures/peerinst_test_data.yaml
``` 
1. Run the development server
```
./manage.py runserver
``` 
1. Navigate to http://127.0.0.1:8000/admin/ and click on an assignment under 'Student progress by assignment'.  From there, find the question table, and click on 'rationales' to see the new report.
1. Append a `perpage` query parameter to see the limit in action, e.g. `?perpage=1`.

**Reviewers**
- [x] @jbzdak 
