### PR TITLE
Granting user staff access if he's an instructor or staff

### DIFF
--- a/dalite/__init__.py
+++ b/dalite/__init__.py
@@ -59,7 +59,9 @@ class ApplicationHookManager(AbstractApplicationHookManager):
                 'question', kwargs=dict(assignment_id=assignment_id, question_id=question_id)
             )
 
-    def authentication_hook(self, request, user_id=None, username=None, email=None, **kwargs):
+    def authentication_hook(self, request, user_id=None, username=None, email=None, extra_params=None):
+        extra = extra_params if extra_params else {}
+
         # have no better option than to automatically generate password from user_id
         password = self._generate_password(user_id, settings.PASSWORD_GENERATOR_NONCE)
 
@@ -80,7 +82,7 @@ class ApplicationHookManager(AbstractApplicationHookManager):
                 # as password and uname are stable (i.e. not change for the same user)
                 logger.info("IntegrityError creating user - assuming result of race condition: %s", e.message)
         authenticated = authenticate(username=uname, password=password)
-        if user and authenticated and 'roles' in kwargs and (self.ADMIN_ACCESS_ROLES & set(kwargs['roles'])):
+        if user and authenticated and 'roles' in extra and (self.ADMIN_ACCESS_ROLES & set(extra['roles'])):
             user.is_staff = True
             user.save()
         login(request, authenticated)

--- a/dalite/__init__.py
+++ b/dalite/__init__.py
@@ -53,7 +53,7 @@ class ApplicationHookManager(AbstractApplicationHookManager):
         question_id = lti_data['custom_question_id']
 
         if request.user.is_staff:
-            return reverse('admin:index')
+            return reverse('admin_index_wrapper')
         else:
             return reverse(
                 'question', kwargs=dict(assignment_id=assignment_id, question_id=question_id)

--- a/dalite/__init__.py
+++ b/dalite/__init__.py
@@ -52,7 +52,7 @@ class ApplicationHookManager(AbstractApplicationHookManager):
         assignment_id = lti_data['custom_assignment_id']
         question_id = lti_data['custom_question_id']
 
-        if request.user.username == 'student':  # studio uses fixed user_id 'student'
+        if request.user.is_staff:
             return reverse('admin:index')
         else:
             return reverse(
@@ -91,6 +91,18 @@ class ApplicationHookManager(AbstractApplicationHookManager):
         return ":".join(str(lti_data[k]) for k in self.LTI_KEYS)
 
     def optional_lti_parameters(self):
+        """
+        Return a dictionary of LTI parameters supported/required by this AuthenticationHookManager in addition
+        to user_id, username and email. These parameters are passed to authentication_hook method via kwargs.
+
+        This dictionary should have LTI parameter names (as specified by LTI specification) as keys; values are used
+        as parameter names passed to authentication_hook method, i.e. it allows renaming (not always intuitive) LTI spec
+        parameter names.
+
+        Example:
+            # renames lis_person_name_given -> user_first_name, lis_person_name_family -> user_lat_name
+            {'lis_person_name_given': 'user_first_name', 'lis_person_name_family': 'user_lat_name'}
+        """
         return {"roles": "roles"}
 
 

--- a/dalite/tests.py
+++ b/dalite/tests.py
@@ -105,7 +105,9 @@ class ApplicationHookManagerTests(SimpleTestCase):
         with mock.patch('dalite.authenticate') as authenticate_mock, mock.patch('dalite.login') as login_mock, \
                 mock.patch.object(user, 'save') as save_mock:
             authenticate_mock.return_value = True
-            self.manager.authentication_hook(request, 'irrelevant', 'irrelevant', 'irrelevant', roles=roles)
+            self.manager.authentication_hook(
+                request, 'irrelevant', 'irrelevant', 'irrelevant', extra_params={'roles': roles}
+            )
 
             self.assertEqual(user.is_staff, is_admin)
             self.assertEqual(save_mock.called, is_admin)

--- a/dalite/tests.py
+++ b/dalite/tests.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.db import IntegrityError
 from django.test import SimpleTestCase
 
-from dalite import ApplicationHookManager
+from dalite import ApplicationHookManager, LTIRoles
 
 
 @ddt.ddt
@@ -86,3 +86,56 @@ class ApplicationHookManagerTests(SimpleTestCase):
             )
             authenticate_mock.assert_called_once_with(username=expected_uname, password=expected_password)
             login_mock.assert_called_once_with(request, auth_result)
+
+    @ddt.unpack
+    @ddt.data(
+        ([], False),
+        (["Unknown role"], False),
+        ([LTIRoles.LEARNER], False),
+        ([LTIRoles.INSTRUCTOR], True),
+        ([LTIRoles.STAFF], True),
+        ([LTIRoles.LEARNER, LTIRoles.INSTRUCTOR], True),
+        ([LTIRoles.LEARNER, LTIRoles.STAFF], True),
+    )
+    def test_authentication_hook_admin_roles(self, roles, is_admin, user_objects_manager):
+        user = User()
+        user_objects_manager.get.return_value = user
+        request = mock.Mock()
+
+        with mock.patch('dalite.authenticate') as authenticate_mock, mock.patch('dalite.login') as login_mock, \
+                mock.patch.object(user, 'save') as save_mock:
+            authenticate_mock.return_value = True
+            self.manager.authentication_hook(request, 'irrelevant', 'irrelevant', 'irrelevant', roles=roles)
+
+            self.assertEqual(user.is_staff, is_admin)
+            self.assertEqual(save_mock.called, is_admin)
+
+    @ddt.unpack
+    @ddt.data(
+        ('assignment_1', 1),
+        ('assignment_2', 2),
+    )
+    def test_authenticated_redirect_normal(self, assignment_id, question_id, user_objects_manager):
+        request = mock.Mock()
+        lti_data = {
+            'custom_assignment_id': assignment_id,
+            'custom_question_id': question_id
+        }
+        expected_redirect = "/assignment/{assignment_id}/{question_id}/".format(
+            assignment_id=assignment_id, question_id=question_id
+        )
+        actual_redirect = self.manager.authenticated_redirect_to(request, lti_data)
+
+        self.assertEqual(actual_redirect, expected_redirect)
+
+    def test_authenticated_redirect_studio_user(self, user_objects_manager):
+        request = mock.Mock()
+        request.user.username = "student"
+        lti_data = {
+            'custom_assignment_id': 'irrelevant',
+            'custom_question_id': 1
+        }
+        expected_redirect = "/admin/"
+        actual_redirect = self.manager.authenticated_redirect_to(request, lti_data)
+
+        self.assertEqual(actual_redirect, expected_redirect)

--- a/dalite/tests.py
+++ b/dalite/tests.py
@@ -119,6 +119,7 @@ class ApplicationHookManagerTests(SimpleTestCase):
     )
     def test_authenticated_redirect_normal(self, assignment_id, question_id, user_objects_manager):
         request = mock.Mock()
+        request.user.is_staff = False
         lti_data = {
             'custom_assignment_id': assignment_id,
             'custom_question_id': question_id
@@ -132,7 +133,7 @@ class ApplicationHookManagerTests(SimpleTestCase):
 
     def test_authenticated_redirect_studio_user(self, user_objects_manager):
         request = mock.Mock()
-        request.user.username = "student"
+        request.user.is_staff = True
         lti_data = {
             'custom_assignment_id': 'irrelevant',
             'custom_question_id': 1

--- a/dalite/urls.py
+++ b/dalite/urls.py
@@ -7,11 +7,14 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
 
+import views
+
 admin.site.site_header = admin.site.site_title = _('Dalite NG administration')
 
 urlpatterns = [
     url(r'', include('peerinst.urls')),
     url(r'^grappelli/', include('grappelli.urls')),
+    url(r'admin_index_wrapper/', views.admin_index_wrapper, name='admin_index_wrapper'),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^lti/', include('django_lti_tool_provider.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/dalite/views.py
+++ b/dalite/views.py
@@ -1,0 +1,18 @@
+from django.core.urlresolvers import reverse
+from django.shortcuts import render_to_response
+from django.http import HttpResponseRedirect
+
+
+def admin_index_wrapper(request):
+    """
+    Redirect to login page outside of an iframe, show help on enabling cookies inside an iframe.
+    We consider the request to come from within an iframe if the HTTP Referer header is set.  This
+    isn't entirely accurate, but should be good enough.
+    """
+    if request.user.is_authenticated():
+        return HttpResponseRedirect(reverse('admin:index'))
+    else:
+        # We probably got here from within the Studio, and the user has third-party cookies disabled,
+        # so we show help on enabling cookies for this site.
+        return render_to_response('peerinst/cookie_help.html', dict(host=request.get_host()))
+

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,5 +5,5 @@ pillow
 
 -e git+https://github.com/open-craft/ansible-sanity-checker@367ae2ff21e64630ebd42daebb188885ab3a625a#egg=sanity_checker
 -e git+https://github.com/tophatmonocle/ims_lti_py.git@979244d83c2e6420d2c1941f58e52f641c56ad12#egg=ims_lti_py-develop
--e git+https://github.com/open-craft/django-lti-tool-provider@v0.0.2#egg=django_lti_tool_provider-master
+-e git+https://github.com/open-craft/django-lti-tool-provider@v0.1.2#egg=django_lti_tool_provider-master
 -e git+https://github.com/edx/opaque-keys@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys


### PR DESCRIPTION
**Description:** Allows AuthenticationHookManager classes accept and request additional LTI parameters.
**Dependencies:** https://github.com/open-craft/xblock-dalite/pull/1

**Testing Instructions:** 
1. Add xblock-dalite to a course (see instructions [there](https://github.com/open-craft/xblock-dalite/pull/1))
2. Choose LTI passport ID, fill in assignment and question ID (all required fields)
3. *Verify:* Dalite XBlock shows Dalite-ng admin interface
4. *Verify:* User can interact with admin interface (i.e. add new assignments and questions, browse answer distributions and stats analysis, etc.)
5. Register new user (say, Staff2) with studio; make sure to activate it.
6. If logged out during registering new user, log back in as course owner. Go to Settings -> Course Team and add Staff2 to course team.
7. Log in as Staff2, open module with dalite-xblocks.
8. *Verify:* Still displays dalite-ng admin, still can interact with them.
9. Log in to LMS as any user with **no** staff access, open module with dalite-xblocks. *Verify:* shows dalite-ng question view
10. Log in to LMS as any user **with** staff access, open module with dalite-xblocks. *Verify:* shows dalite-ng question view