### PR TITLE
Bump ansible-sanity-checker.

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,7 @@ django-grappelli>=2.7.1,<2.8
 mysql-python
 pillow
 
--e git+https://github.com/open-craft/ansible-sanity-checker@367ae2ff21e64630ebd42daebb188885ab3a625a#egg=sanity_checker
+-e git+https://github.com/open-craft/ansible-sanity-checker@v0.0.2#egg=sanity_checker
 -e git+https://github.com/tophatmonocle/ims_lti_py.git@979244d83c2e6420d2c1941f58e52f641c56ad12#egg=ims_lti_py-develop
 -e git+https://github.com/open-craft/django-lti-tool-provider@v0.1.2#egg=django_lti_tool_provider-master
 -e git+https://github.com/edx/opaque-keys@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys


### PR DESCRIPTION
Dependency of dalite had an error in `setup.py` which resulted in error when installing without `-e` option. 

To test: 
1. Create python virtualenv, `pip install git+https://github.com/open-craft/ansible-sanity-checker@367ae2ff21e64630ebd42daebb188885ab3a625a#egg=sanity_checker`. Notice that if you run `python` and `import sanity_check` you get import error. 
2. `pip install git+https://github.com/open-craft/ansible-sanity-checker@v0.0.2#egg=sanity_checker` notice the problem goes away.. 

See also https://github.com/open-craft/ansible-sanity-checker/pull/4