### PR TITLE
Fix two issues with staff users in dalite-xblock

### DIFF
--- a/dalite/__init__.py
+++ b/dalite/__init__.py
@@ -59,7 +59,13 @@ class ApplicationHookManager(AbstractApplicationHookManager):
         assignment_id = lti_data['custom_assignment_id']
         question_id = lti_data['custom_question_id']
 
-        if request.user.is_staff:
+        user = request.user
+
+        # There is no direct way to detect whether request was made from Studio or from LMS. Best way we could thought
+        # of was to check if username equals to "student". Studio seems to fix username to this value for every LTI
+        # call. Additionally we check whether user has appropriate role --- so if by some accident student will get
+        # username "student" (instead of anonymized username) he still will get redirected to question.
+        if user.is_staff and user.username == "student":
             return reverse('admin_index_wrapper')
         else:
             return reverse(

--- a/dalite/tests.py
+++ b/dalite/tests.py
@@ -144,6 +144,7 @@ class ApplicationHookManagerTests(SimpleTestCase):
     def test_authenticated_redirect_studio_user(self, user_objects_manager):
         request = mock.Mock()
         request.user.is_staff = True
+        request.user.username = "student"
         lti_data = {
             'custom_assignment_id': 'irrelevant',
             'custom_question_id': 1

--- a/dalite/tests.py
+++ b/dalite/tests.py
@@ -88,30 +88,39 @@ class ApplicationHookManagerTests(SimpleTestCase):
             authenticate_mock.assert_called_once_with(username=expected_uname, password=expected_password)
             login_mock.assert_called_once_with(request, auth_result)
 
-    @ddt.unpack
-    @ddt.data(
-        ([], False),
-        (["Unknown role"], False),
-        ([LTIRoles.LEARNER], False),
-        ([LTIRoles.INSTRUCTOR], True),
-        ([LTIRoles.STAFF], True),
-        ([LTIRoles.LEARNER, LTIRoles.INSTRUCTOR], True),
-        ([LTIRoles.LEARNER, LTIRoles.STAFF], True),
-    )
-    def test_authentication_hook_admin_roles(self, roles, is_admin, user_objects_manager):
+    @ddt.data(True, False)
+    def test_authentication_hook_admin_roles(self, is_admin, user_objects_manager):
         user = User()
         user_objects_manager.get.return_value = user
         request = mock.Mock()
 
         with mock.patch('dalite.authenticate') as authenticate_mock, mock.patch('dalite.login') as login_mock, \
-                mock.patch.object(user, 'save') as save_mock:
-            authenticate_mock.return_value = True
+                mock.patch.object(ApplicationHookManager, 'is_user_staff') as is_user_staff, \
+                mock.patch.object(ApplicationHookManager, 'update_staff_user') as update_staff_user:
+
+            authenticate_mock.return_value = user
+            is_user_staff.return_value = is_admin
+
             self.manager.authentication_hook(
-                request, 'irrelevant', 'irrelevant', 'irrelevant', extra_params={'roles': roles}
+                request, 'irrelevant', 'irrelevant', 'irrelevant'
             )
 
-            self.assertEqual(user.is_staff, is_admin)
-            self.assertEqual(save_mock.called, is_admin)
+            self.assertEqual(update_staff_user.called, is_admin)
+
+    @ddt.unpack
+    @ddt.data(
+        ({}, False),
+        ({"roles": []}, False),
+        ({"roles": ["Unknown role"]}, False),
+        ({"roles": [LTIRoles.LEARNER]}, False),
+        ({"roles": [LTIRoles.INSTRUCTOR]}, True),
+        ({"roles": [LTIRoles.STAFF]}, True),
+        ({"roles": [LTIRoles.LEARNER, LTIRoles.INSTRUCTOR]}, True),
+        ({"roles": [LTIRoles.LEARNER, LTIRoles.STAFF]}, True),
+    )
+    def test_is_staff_user(self, extra_args, is_staff_expected, user_objects_manager):
+        is_staff_actual = self.manager.is_user_staff(extra_args)
+        self.assertEqual(is_staff_actual, is_staff_expected)
 
     @ddt.unpack
     @ddt.data(
@@ -143,6 +152,21 @@ class ApplicationHookManagerTests(SimpleTestCase):
         actual_redirect = self.manager.authenticated_redirect_to(request, lti_data)
 
         self.assertEqual(actual_redirect, expected_redirect)
+
+
+class TestUpdateStaffUser(TestCase):
+    def setUp(self):
+        self.manager = ApplicationHookManager()
+
+    def test_update_staff_user(self):
+        expected_perms = {
+            u'add_assignment', u'change_assignment', u'add_question', u'change_question',
+            u'add_category', u'change_category'
+        }
+        user = User.objects.create(username="test")
+        self.manager.update_staff_user(user)
+        actual_perms = set((p.codename for p in user.user_permissions.all()))
+        self.assertEqual(expected_perms, actual_perms)
 
 
 class TestViews(TestCase):

--- a/peerinst/templates/admin/peerinst/index.html
+++ b/peerinst/templates/admin/peerinst/index.html
@@ -41,11 +41,13 @@
             {% trans 'Question categories' %}
         </a></p>
       </div>
+      {% if "auth.add_user" in perms %}
       <div class="grp-row">
         <p><a href="{% url 'admin:app_list' app_label='auth' %}">
             {% trans 'Users' %}
         </a></p>
       </div>
+      {% endif %}
       <div class="grp-row">
         <p><a href="{% url 'fake-usernames' %}">
             {% trans 'Fake usernames' %}


### PR DESCRIPTION
# Setup steps

1. Install xblock-dalite in your devstack
2. Run dalite (from master) 
3. Create a LTI passport for `dalite-xblock`, on my system it looked this way `(dalite-xblock)dalite;http://192.168.33.1:10100;alpha;beta`. Note: `(dalite-xblock)` is a magic tag. `http://192.168.33.1:10100` is a base for the instance (`LTI` module would require `http://192.168.33.1:10100/lti/`). `alpha;beta` are `LTI_CLIENT_KEY` and `LTI_CLIENT_SECRET`. Note everything is delimited by ';' instead od `:`. 
4. Add dalite xblock to a course. 

# Reproduce errors

1. Run dalite from master banch. 
2. Login as staff user, and go to studio. 
3. Notice that while you see admin GUI you don't have any rights, and when you click to edit questions you get `403` error. 
4. Go to LMS (still logged as staff) notice that you see admin panel. 

# Verify fix 

1. Run dalite from this branch. 
2. Login as staff user, and go to studio. 
3. Notice that you may add/edit questions. 
4. When you go to LMS you see assignment you have choosen for the xblock. 
5. Notice that from Studio you don't see link for user administration. 
6. Verify that it is still visible if you login as superuser. 