### PR TITLE
Expire LTI sessions on browser close.

### DIFF
--- a/dalite/__init__.py
+++ b/dalite/__init__.py
@@ -87,6 +87,15 @@ class ApplicationHookManager(AbstractApplicationHookManager):
             user.save()
         login(request, authenticated)
 
+        # LTI sessions are created implicitly, and are not terminated when user logs out of Studio/LMS, which may lead
+        # to granting access to unauthorized users in shared computer setting. Students have no way to terminate dalite
+        # session (other than cleaning cookies). This setting instructs browser to clear session when browser is
+        # closed --- this allows staff user to terminate the session easily. which decreases the chance of
+        # session hijacking in shared computer environment.
+
+        # TL; DR; Sets session expiry on browser close.
+        request.session.set_expiry(0)
+
     def vary_by_key(self, lti_data):
         return ":".join(str(lti_data[k]) for k in self.LTI_KEYS)
 


### PR DESCRIPTION
# Description

This PR introduced a feature that asks browsers to clear the session after browser is closed. This is done for LTI sessions only, so normal "admin" users are not affected. 

LTI sessions are created implicitly, and are not terminated when user logs out of Studio/LMS, which may lead to granting access to unauthorized users in shared computer setting. Students have no way to terminate dalite  session (other than cleaning cookies). This setting instructs browser to clear session when browser is closed --- this allows staff user to terminate the session easily. which decreases the chance of session hijacking in shared computer environment.

# Verification instructions

1. Use master dalite. 
2. Use LTI/xblock-lti-consumer/xblock-dalite and open this xbliock in Studio. 
3. Go to the dalite instance, if you set `http://192.168.33.1` as a base url in xblock dalite go to this address. Your session should be valid for dalite. 
4. Close browser. 
5. Directly open dalite, you should be logged in automatically. 

# Testing instructions. 
1. Use master dalite. 
2. Use LTI/xblock-lti-consumer/xblock-dalite and open this xbliock in Studio. 
3. Go to the dalite instance, if you set `http://192.168.33.1` as a base url in xblock dalite go to this address. Your session should be valid for dalite. 
4. Close browser. 
5. You should get a login prompt. 