### PR TITLE
Improving rationale aggregate query to run inside database

### DIFF
--- a/peerinst/admin_views.py
+++ b/peerinst/admin_views.py
@@ -132,15 +132,20 @@ def get_question_rationale_aggregates(assignment, question, perpage):
     def _top_rationales(answer_list):
         # Count the chosen rationales for the given answer list
 
-        counts = answer_list.select_related('chosen_rationale')\
-                            .values('chosen_rationale')\
-                            .annotate(count=Count('chosen_rationale'), rationale=F('chosen_rationale'))\
-                            .order_by('-count')\
-                            .values('count', 'rationale')
-        sorted_list = counts
+        sorted_list = answer_list.select_related('chosen_rationale')\
+                            .annotate(choice_count=Count('chosen_rationale'))\
+                            .order_by('-choice_count')
+        number_of_rationales = sorted_list.count()
+        sorted_list = [
+            {
+                'count': answer.choice_count,
+                'rationale': answer.chosen_rationale
+            }
+            for answer in sorted_list[:perpage]
+        ]
 
         #Return a list of dicts, sorted by descending count
-        return sorted_list[:perpage], sorted_list.count()
+        return sorted_list, number_of_rationales
 
     # Collect the upvoted rationales, sorted by descending upvotes
     output = {'upvoted': []}

--- a/peerinst/tests/test_admin_views.py
+++ b/peerinst/tests/test_admin_views.py
@@ -129,7 +129,7 @@ class TopRationalesTestCase(TestCase):
 
     @ddt.data(0, 100, 2, 1500)
     def test_large_data(self, perpage):
-        with self.assertNumQueries(6 if perpage else 5):
+        with self.assertNumQueries(9 if perpage else 5):
             sums, rationales = admin_views.get_question_rationale_aggregates(self.assignment, self.question, perpage)
         self.assertEquals(sums['upvoted'], 4500)
         self.assertEquals(len(rationales['upvoted']), perpage if perpage < 4500 else 4500)


### PR DESCRIPTION
This PR contains minor optimization to the `get_question_rationale_aggregate` query by moving counting and sorting into the database. This results in a small linear performance increase.

This came about as a result of investigating the performance of the report on large sample sizes; we saw poor performance when testing with large (~50,000 records) sample record sets. It was determined that the performance issues were due to record creation and not the query, and were therefore not a concern, but this change had already been made.

**Dependencies**: None

**Testing instructions**:

1. View the Dalite admin reports and observe that behavior seems generally unchanged compared to what it is at present.

**Reviewers**
- [ ] @bradenmacdonald 