### PR TITLE
Support arbitrary course_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,47 @@ Click "Save". At this point, the Dalite question should be visible in Studio.
 
 **Note:** it is important that the Studio and Dalite URL domains are different; here they are deliberately chosen to be "192.168.33.10" and "localhost".  This difference is necessary to prevent cookies clashing.
 
+Usage Example: Configuring Dalite in Moodle
+-------------------------------------------
+
+_**Note**: For the purposes of these example setup instructions, it is assumed that you already have a working local Moodle and a locally running Dalite LTI server._
+
+* Go to Dalite at [http://192.168.33.10:8321/admin/](http://192.168.33.10:8321/admin/) and login with the superuser login you created (see above steps). Note that we use the IP address 192.168.33.10 which is automatically setup for devstacks, so we don't have to fiddle around with port forwarding settings.
+
+* Click "Questions" and create a couple of questions.
+
+* Click "Assignments" and create a new assignment with identifier "assign1". Add the questions previously created to "Chosen questions" for the assignment.
+
+* Navigate to a Moodle course as a course Instructor.
+
+* Click the "Turn editing on" button in the top right corner: ![](http://i.imgur.com/yiOlqse.png)
+
+* Click "Add an activity or resource" on a topic, and then select "External Tool" ![](http://i.imgur.com/TnVuoLu.png)
+
+* Click the "+" (![](http://i.imgur.com/dI6aKpQ.png)) next to the "External tool type" field and configure a new External Tool type (this will be the configuration for the Dalite LTI server):
+  - Fill out a "Tool name" of your choosing.
+  - Set the tool base URL to `http://192.168.33.10:8321/lti/`.
+  - Set the "Consumer key" to `alpha`.
+  - Set the "Shared secret" to `beta`.
+  - Leave the "Custom parameters" field blank.
+  - Set "Default launch container" to "Embed, without blocks".
+  - Click "Save changes".
+
+    ![](http://i.imgur.com/QRVEcRy.png)
+* Return to the "Adding a new External tool" configuration, and create a new activity:
+  - Fill out an "Activity name" of your choosing.
+  - Set the "External tool type" to be the name of the tool type you just created.
+  - Click "Show more...": ![](http://i.imgur.com/XRBSqag.png)
+  - Set the "Custom parameters" to the following, noting that each parameter is on a separate line (change this field when creating each new activity with problems from the same Dalite LTI server):
+
+    ```
+assignment_id=assign1
+question_id=1
+```
+    ![](http://i.imgur.com/sCnMy5B.png)
+  - Click "Save and Display" (![](http://i.imgur.com/XgGTSbE.png)) to see if your new problem works!
+    ![](http://i.imgur.com/epLoE1X.png)
+
 Running the tests
 -----------------
 


### PR DESCRIPTION
This fix allows an LMS to specify arbitrary course_ids so that dalite-ng
can work with other LMSs besides edX, like moodle.

### edX test instructions:

1. Setup a devstack.
1. Follow these instructions to setup dalite-ng in the devstack, but be sure to checkout this branch (bdero/remove-opaque-keys) when cloning the dalite-ng repo: https://github.com/open-craft/dalite-ng#setting-up-a-development-server-in-an-open-edx-devstack
1. Follow these instructions to setup a dalite-ng problem on a course: https://github.com/open-craft/dalite-ng#usage-example-configuring-dalite-in-edx-studio
1. Publish the new problem in Studio.
1. With the LMS and dalite-ng LTI apps both running, open a new terminal and `vagrant ssh`.
1. With the new ssh session, tail the student log for dalite-ng: `tail -f /edx/src/dalite-ng/log/student.log`
1. Navigate to the dalite-ng LTI problem in the LMS. Observe that there are no errors.
1. Look at the `student.log` tail, notice that the event log just emitted doesn't have an "org_id" field. It should look something like this:

    ```json
    {"username": "QdwEdCbdw1uPCF2LDPVk3g++", "context": {"username": "QdwEdCbdw1uPCF2LDPVk3g++", "course_id": "course-v1:edX+DemoX+Demo_Course", "module": {"usage_key": null}}, "event_source": "server", "event_type": "problem_show", "ip": "192.168.33.1", "agent": "Mozilla/5.0 (X11; Linux x86_64; rv:48.0) Gecko/20100101 Firefox/48.0", "host": "precise64", "referer": "http://localhost:8000/courses/course-v1:edX+DemoX+Demo_Course/xblock/block-v1:edX+DemoX+Demo_Course+type@lti+block@5f53a36d78a34d219c165c3f41fc29d3/handler/preview_handler", "accept_language": "en-US,en;q=0.5", "time": "2016-09-08T20:18:54.578471", "course_id": "course-v1:edX+DemoX+Demo_Course", "event": {"assignment_id": "assign1", "problem": null, "question_text": "What letter does Brandon start with?", "assignment_title": "Test Assignment!", "question_id": 1}}
    ```

    Before the change, it looked like this (notice the "org_id" right after the "course_id" field:
    ```json
    {"username": "QdwEdCbdw1uPCF2LDPVk3g++", "context": {"username": "QdwEdCbdw1uPCF2LDPVk3g++", "course_id": "course-v1:edX+DemoX+Demo_Course", "org_id": "edX", "module": {"usage_key": null}}, "event_source": "server", "event_type": "problem_check", "ip": "192.168.33.1", "agent": "Mozilla/5.0 (X11; Linux x86_64; rv:48.0) Gecko/20100101 Firefox/48.0", "host": "precise64", "referer": "http://192.168.33.10:8321/assignment/assign1/1/", "accept_language": "en-US,en;q=0.5", "time": "2016-09-08T19:40:36.248539", "course_id": "course-v1:edX+DemoX+Demo_Course", "event": {"question_text": "What letter does Brandon start with?", "success": "correct", "assignment_id": "assign1", "assignment_title": "Test Assignment!", "rationale": "sdsdf  ffff", "problem": null, "first_answer_choice": 2, "question_id": 1}}

    ```

### Moodle test instructions:

1. Set up dalite-ng app using the branch from this PR.
1. Configured nginx to use SSL, and proxied dalite-ng.  The proxy configuration was crucial to getting OAuth handshaking to work, but maybe there's another way to do it?

    ```
server {
	listen 443;
	server_name dalite-server-name.com;

	ssl on;
	ssl_certificate /etc/letsencrypt/live/dalite-server-name.com/cert.pem;
	ssl_certificate_key /etc/letsencrypt/live/dalite-server-name.com/privkey.pem;
	ssl_session_timeout 5m;
	ssl_protocols SSLv3 TLSv1;
	ssl_ciphers ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv3:+EXP;
	ssl_prefer_server_ciphers on;

	location / {
            proxy_pass http://127.0.0.1:8321;
            proxy_redirect http://127.0.0.1:8321 https://dalite-server-name.com;
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
	}
}
```
1. Created a couple of Questions and an Assignment as per [README](https://github.com/open-craft/dalite-ng#usage-example-configuring-dalite-in-edx-studio).  Also had to Preview each question, and provide sample "expert" rationales for each possible answer choice, otherwise the student answers couldn't be graded.
1. Set up an individual `External Tool` assignment in Moodle for each question ([Q1](https://moodle.dawsoncollege.qc.ca/course/mod.php?sesskey=gCcZK5Lafb&sr=0&update=15329), [Q2](https://moodle.dawsoncollege.qc.ca/course/mod.php?sesskey=gCcZK5Lafb&sr=0&update=15334)).
1. Impersonated a Student and answered Q1 correctly, and Q2 incorrectly.
1. Checked [Grades](https://moodle.dawsoncollege.qc.ca/grade/report/user/index.php?id=504) to ensure they got recorded ok.