### PR TITLE
Add results view option

### DIFF
--- a/dalite/__init__.py
+++ b/dalite/__init__.py
@@ -77,6 +77,7 @@ class ApplicationHookManager(AbstractApplicationHookManager):
         action = lti_data.get('custom_action')
         assignment_id = lti_data.get('custom_assignment_id')
         question_id = lti_data.get('custom_question_id')
+        show_results_view = lti_data.get('custom_show_results_view', 'false')
 
         if action == 'launch-admin':
             return reverse('admin:index')
@@ -85,9 +86,10 @@ class ApplicationHookManager(AbstractApplicationHookManager):
                 'admin:peerinst_question_change', args=(question_id,)
             )
 
-        return reverse(
-            'question', kwargs=dict(assignment_id=assignment_id, question_id=question_id)
-        )
+        redirect_url =  reverse('question', kwargs=dict(assignment_id=assignment_id, question_id=question_id))
+        if show_results_view == 'true':
+            redirect_url += '?show_results_view=true'
+        return redirect_url
 
     def authentication_hook(self, request, user_id=None, username=None, email=None, extra_params=None):
         if extra_params is None:

--- a/peerinst/templates/peerinst/question_answers_summary.html
+++ b/peerinst/templates/peerinst/question_answers_summary.html
@@ -1,0 +1,38 @@
+{% extends 'peerinst/base.html' %}
+{% load i18n %}
+{% block title %}{{ question.title }}{% endblock %}
+{% block body %}
+    <h1>Answer Analysis - {{ question.title }}</h1>
+    <h2>Analytics</h2>
+    <div class="meta-container">
+        <table style="width:100%">
+            <thead>
+                <tr>
+                    {% for column in columns %}
+                        <th>{{ column.label }}</th>
+                    {% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for answer in answer_rows %}
+                    <tr>
+                        {% for column in answer %}
+                            <td>{{ column }}</td>
+                        {% endfor %}
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <h2>Top Rationales by Answer</h2>
+    <div class="meta-container">
+        {% for answer_option in answer_rationales %}
+            {% if answer_option.rationales %}
+                <h3>{{ answer_option.label}}</h3>
+                {% for rationale in answer_option.rationales %}
+                    <ol>{{ rationale.count }} - {{ rationale.text }}</ol>
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/peerinst/tests/test_admin_views.py
+++ b/peerinst/tests/test_admin_views.py
@@ -101,7 +101,7 @@ class TopRationalesTestData(object):
         return (assignment, question)
 
     @staticmethod
-    def mock_rationale_aggregates(question, assignment, perpage):
+    def mock_rationale_aggregates(question, assignment, perpage, *args, **kwargs):
         sums = {'upvoted': 1, 'chosen': 150, 'right_to_wrong': 12, 'wrong_to_right': 50}
         answer = mock.Mock()
 


### PR DESCRIPTION
This PR will add a "results" view that shows a table of the answers selected for a given question.

**Screenshots**:

<img width="912" alt="screen shot 2016-10-26 at 10 10 59 am" src="https://cloud.githubusercontent.com/assets/7773758/19729342/b2529b7c-9b64-11e6-9628-1b172b8aba06.png">


**Sandbox URL**: N/A

**Testing instructions**:

1. Install dalite-ng from this branch in a devstack per the repo instructions.
2. Set up an assignment, with question and answers
3. Use multiple devstack users (staff, honor, verified, etc) to answer the question in a number of ways, selecting different rationales.
4. Add the custom variable `"show_results_view=true"` to the LTI block.
5. Refresh the page and view a chart showing the statistics for the different answers, as well as the most convincing rationales for each answer.
6. Run tests locally (no CI on this repo)

**Reviewers**
- [ ] @itsjeyd 