### PR TITLE
Add Results View HTML Box

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ dalite$ cd dalite-ng
 
 * Install the requirements
 ```shell
-dalite$ pip install -r requirements.txt
+dalite$ pip install -r requirements/requirements.txt
 ```
 
 * Generate a secret key using `tools/gen_secret_key.py`, and put it in `dalite/local_settings.py`.

--- a/peerinst/static/peerinst/css/main.css
+++ b/peerinst/static/peerinst/css/main.css
@@ -155,3 +155,10 @@ input[type="submit"].thumbs-down {
 .votable-rationale q {
     font-style: italic;
 }
+.share-question-answers-summary label {
+    font-weight: bold;
+}
+.share-question-answers-summary textarea {
+    width: 50%;
+    height: 100px;
+}

--- a/peerinst/static/peerinst/js/question_answers_summary.js
+++ b/peerinst/static/peerinst/js/question_answers_summary.js
@@ -1,0 +1,5 @@
+$(function() {
+    $('.share-question-answers-summary textarea').click(function() {
+        $(this).focus().select();
+    });
+});

--- a/peerinst/templates/peerinst/_question_answers_summary.html
+++ b/peerinst/templates/peerinst/_question_answers_summary.html
@@ -1,0 +1,34 @@
+<h1>Answer Analysis - {{ question.title }}</h1>
+<h2>Analytics</h2>
+<div class="meta-container">
+    <table style="width:100%">
+        <thead>
+            <tr>
+                {% for column in columns %}
+                    <th>{{ column.label }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for answer in answer_rows %}
+                <tr>
+                    {% for column in answer %}
+                        <td>{{ column }}</td>
+                    {% endfor %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+<h2>Top Rationales by Answer</h2>
+<div class="meta-container">
+    {% for answer_option in answer_rationales %}
+        {% if answer_option.rationales %}
+            <h3>{{ answer_option.label}}</h3>
+            {% for rationale in answer_option.rationales %}
+                <ol>{{ rationale.count }} - {{ rationale.text }}</ol>
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+</div>
+

--- a/peerinst/templates/peerinst/question_answers_summary.html
+++ b/peerinst/templates/peerinst/question_answers_summary.html
@@ -1,38 +1,22 @@
 {% extends 'peerinst/base.html' %}
 {% load i18n %}
+{% load static %}
 {% block title %}{{ question.title }}{% endblock %}
 {% block body %}
-    <h1>Answer Analysis - {{ question.title }}</h1>
-    <h2>Analytics</h2>
-    <div class="meta-container">
-        <table style="width:100%">
-            <thead>
-                <tr>
-                    {% for column in columns %}
-                        <th>{{ column.label }}</th>
-                    {% endfor %}
-                </tr>
-            </thead>
-            <tbody>
-                {% for answer in answer_rows %}
-                    <tr>
-                        {% for column in answer %}
-                            <td>{{ column }}</td>
-                        {% endfor %}
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
-    <h2>Top Rationales by Answer</h2>
-    <div class="meta-container">
-        {% for answer_option in answer_rationales %}
-            {% if answer_option.rationales %}
-                <h3>{{ answer_option.label}}</h3>
-                {% for rationale in answer_option.rationales %}
-                    <ol>{{ rationale.count }} - {{ rationale.text }}</ol>
-                {% endfor %}
-            {% endif %}
-        {% endfor %}
-    </div>
+<!-- Show the summary table-->
+<div class="question-answers-summary">
+{% include 'peerinst/_question_answers_summary.html' %}
+</div>
+
+<!-- Show the HTML itself in a non-editable textarea, so course teams can copy-paste and share it.-->
+<div class="share-question-answers-summary">
+<label>Click below to select the HTML table, and copy to share the results.</br>
+<textarea readonly="readonly">
+{% include 'peerinst/_question_answers_summary.html' %}
+</textarea></label>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="{% static 'peerinst/js/question_answers_summary.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Encloses the raw HTML used to display the Question/Answer results table into a readonly textarea.  Clicking on the textarea automatically selects the text inside.

**Screenshots**:

![screen shot 2016-11-17 at 6 22 47 pm](https://cloud.githubusercontent.com/assets/7556571/20380580/e1be021c-acf2-11e6-8133-b168cfedc790.png)

**Sandbox URL**: none

**Merge deadline**: 18 Nov 2016

**Testing instructions**:

1. Follow the steps for setting up the question/answer results view in https://github.com/open-craft/dalite-ng/pull/59
2. When you reach the results view page, click on the textarea to see that the text gets selected.

**Reviewers**
- [x] @smarnach 