### PR TITLE
Switch to an unreleased httplib2 version to add SNI support

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,6 +3,9 @@ django-grappelli>=2.7.1,<2.8
 mysql-python
 pillow
 
+# need an unreleased SNI fix from httplib2 lib TODO: remove after it is released to PyPi
+-e git+https://github.com/httplib2/httplib2.git@5ccd260911e2db802fa97498ae92558fac8c8057#egg=httplib2-0.9.2_dev
+
 -e git+https://github.com/open-craft/ansible-sanity-checker@v0.0.2#egg=sanity_checker
 -e git+https://github.com/tophatmonocle/ims_lti_py.git@979244d83c2e6420d2c1941f58e52f641c56ad12#egg=ims_lti_py-develop
 -e git+https://github.com/open-craft/django-lti-tool-provider@v0.1.3#egg=django_lti_tool_provider-master


### PR DESCRIPTION
**Description:** This PR pins httplib2 used with dalite-ng to SNI-enabled version.

**Testing instructions:**

1. Create virtualenv and run `pip install -r requirements/requirements.txt`
2. Execute the following script in virtualenv:

    from httplib2 import Http
    Http().request("https://courses.mydalite.org", method="GET")

*Expected result:* successfully loads https://courses.mydalite.org index page.
*Failure condition:* reports any kind of SSL error (though `httplib2.SSLHandshakeError: [SSL: TLSV1_UNRECOGNIZED_NAME] tlsv1 unrecognized name (_ssl.c:590)` is expected).

**Reviewers:**
- [ ] @haikuginger 